### PR TITLE
Monkey patch in util namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## 3.0.0 3rd March 2021
+ - Breaking: Move `apply_monkey_patches()` directly to `botcore.utils` namespace
+
 ## 2.1.0 24th February 2022
  - Feature: Port the Site API wrapper from the bot repo.
 
 ## 2.0.0 22nd February 2022
-- Breaking: Moved regex to botcore.utils namespace
+- Breaking: Moved regex to `botcore.utils` namespace
 - Feature: Migrate from discord.py 2.0a0 to disnake.
 - Feature: Add common monkey patches.
 - Feature: Port many common utilities from our bots

--- a/botcore/utils/__init__.py
+++ b/botcore/utils/__init__.py
@@ -1,14 +1,31 @@
 """Useful utilities and tools for Discord bot development."""
 
-from botcore.utils import (caching, channel, extensions, logging, members, monkey_patches, regex, scheduling)
+from botcore.utils import _monkey_patches, caching, channel, extensions, logging, members, regex, scheduling
+
+
+def apply_monkey_patches() -> None:
+    """
+    Applies all common monkey patches for our bots.
+
+    Patches :obj:`disnake.ext.commands.Command` and :obj:`disnake.ext.commands.Group` to support root aliases.
+        A ``root_aliases`` keyword argument is added to these two objects, which is a sequence of alias names
+        that will act as top-level groups rather than being aliases of the command's group.
+
+        It's stored as an attribute also named ``root_aliases``
+
+    Patches disnake's internal ``send_typing`` method so that it ignores 403 errors from Discord.
+        When under heavy load Discord has added a CloudFlare worker to this route, which causes 403 errors to be thrown.
+    """
+    _monkey_patches._apply_monkey_patches()
+
 
 __all__ = [
+    apply_monkey_patches,
     caching,
     channel,
     extensions,
     logging,
     members,
-    monkey_patches,
     regex,
     scheduling,
 ]

--- a/botcore/utils/_monkey_patches.py
+++ b/botcore/utils/_monkey_patches.py
@@ -62,19 +62,8 @@ def _patch_typing() -> None:
     http.HTTPClient.send_typing = honeybadger_type
 
 
-def apply_monkey_patches() -> None:
-    """
-    Applies all common monkey patches for our bots.
-
-    Patches :obj:`disnake.ext.commands.Command` and :obj:`disnake.ext.commands.Group` to support root aliases.
-        A ``root_aliases`` keyword argument is added to these two objects, which is a sequence of alias names
-        that will act as top-level groups rather than being aliases of the command's group.
-
-        It's stored as an attribute also named ``root_aliases``
-
-    Patches disnake's internal ``send_typing`` method so that it ignores 403 errors from Discord.
-        When under heavy load Discord has added a CloudFlare worker to this route, which causes 403 errors to be thrown.
-    """
+def _apply_monkey_patches() -> None:
+    """This is surfaced directly in botcore.utils.apply_monkey_patches()."""
     commands.command = partial(commands.command, cls=_Command)
     commands.GroupMixin.command = partialmethod(commands.GroupMixin.command, cls=_Command)
 

--- a/docs/utils.py
+++ b/docs/utils.py
@@ -105,7 +105,10 @@ def __get_included() -> set[str]:
     """Get a list of files that should be included in the final build."""
 
     def get_all_from_module(module_name: str) -> set[str]:
-        module = importlib.import_module(module_name)
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError:
+            return {}
         _modules = {module.__name__ + ".rst"}
 
         if hasattr(module, "__all__"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot-core"
-version = "2.1.0"
+version = "3.0.0"
 description = "Bot-Core provides the core functionality and utilities for the bots of the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"


### PR DESCRIPTION
This moves apply_monkey_patches directly to the utils namespace, avoiding a janky API.

Renamed the module to `_monkey_patches` so that it doesn't get included in the auto docs.

Had to update the cleanup function so that it didn't raise an error if a member on `__all__` wasn't a function (EG a function).