### PR TITLE
Set the logger class in `logging.py` to `CustomLogger`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 3.0.0 3rd March 2021
+## 3.0.1 5th March 2022
+- Fix: Setup log tracing when `botcore.utils.logging` is imported so that it can be used within botcore functions.
+
+## 3.0.0 3rd March 2022
  - Breaking: Move `apply_monkey_patches()` directly to `botcore.utils` namespace
 
 ## 2.1.0 24th February 2022

--- a/botcore/utils/logging.py
+++ b/botcore/utils/logging.py
@@ -43,3 +43,9 @@ def get_logger(name: typing.Optional[str] = None) -> CustomLogger:
         An instance of the :obj:`CustomLogger` class.
     """
     return typing.cast(CustomLogger, logging.getLogger(name))
+
+
+# Setup trace level logging so that we can use it within botcore.
+logging.TRACE = TRACE_LEVEL
+logging.setLoggerClass(CustomLogger)
+logging.addLevelName(TRACE_LEVEL, "TRACE")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot-core"
-version = "3.0.0"
+version = "3.0.1"
 description = "Bot-Core provides the core functionality and utilities for the bots of the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"


### PR DESCRIPTION
Fixes an issue when using trace logging on loggers that were instantiated before the class was set.