### PR TITLE
Revert disnake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.0 14th March 2022
+- Breaking: Migrate back to Discord.py 2.0
+
 ## 3.0.1 5th March 2022
 - Fix: Setup log tracing when `botcore.utils.logging` is imported so that it can be used within botcore functions.
 

--- a/botcore/utils/__init__.py
+++ b/botcore/utils/__init__.py
@@ -7,13 +7,13 @@ def apply_monkey_patches() -> None:
     """
     Applies all common monkey patches for our bots.
 
-    Patches :obj:`disnake.ext.commands.Command` and :obj:`disnake.ext.commands.Group` to support root aliases.
+    Patches :obj:`discord.ext.commands.Command` and :obj:`discord.ext.commands.Group` to support root aliases.
         A ``root_aliases`` keyword argument is added to these two objects, which is a sequence of alias names
         that will act as top-level groups rather than being aliases of the command's group.
 
         It's stored as an attribute also named ``root_aliases``
 
-    Patches disnake's internal ``send_typing`` method so that it ignores 403 errors from Discord.
+    Patches discord's internal ``send_typing`` method so that it ignores 403 errors from Discord.
         When under heavy load Discord has added a CloudFlare worker to this route, which causes 403 errors to be thrown.
     """
     _monkey_patches._apply_monkey_patches()

--- a/botcore/utils/_monkey_patches.py
+++ b/botcore/utils/_monkey_patches.py
@@ -1,18 +1,18 @@
-"""Contains all common monkey patches, used to alter disnake to fit our needs."""
+"""Contains all common monkey patches, used to alter discord to fit our needs."""
 
 import logging
 from datetime import datetime, timedelta
 from functools import partial, partialmethod
 
-from disnake import Forbidden, http
-from disnake.ext import commands
+from discord import Forbidden, http
+from discord.ext import commands
 
 log = logging.getLogger(__name__)
 
 
 class _Command(commands.Command):
     """
-    A :obj:`disnake.ext.commands.Command` subclass which supports root aliases.
+    A :obj:`discord.ext.commands.Command` subclass which supports root aliases.
 
     A ``root_aliases`` keyword argument is added, which is a sequence of alias names that will act as
     top-level commands rather than being aliases of the command's group. It's stored as an attribute
@@ -29,7 +29,7 @@ class _Command(commands.Command):
 
 class _Group(commands.Group, _Command):
     """
-    A :obj:`disnake.ext.commands.Group` subclass which supports root aliases.
+    A :obj:`discord.ext.commands.Group` subclass which supports root aliases.
 
     A ``root_aliases`` keyword argument is added, which is a sequence of alias names that will act as
     top-level groups rather than being aliases of the command's group. It's stored as an attribute
@@ -41,7 +41,7 @@ def _patch_typing() -> None:
     """
     Sometimes Discord turns off typing events by throwing 403s.
 
-    Handle those issues by patching disnake's internal ``send_typing`` method so it ignores 403s in general.
+    Handle those issues by patching discord's internal ``send_typing`` method so it ignores 403s in general.
     """
     log.debug("Patching send_typing, which should fix things breaking when Discord disables typing events. Stay safe!")
 

--- a/botcore/utils/channel.py
+++ b/botcore/utils/channel.py
@@ -1,14 +1,14 @@
-"""Useful helper functions for interacting with various disnake channel objects."""
+"""Useful helper functions for interacting with various discord channel objects."""
 
-import disnake
-from disnake.ext.commands import Bot
+import discord
+from discord.ext.commands import Bot
 
 from botcore.utils import logging
 
 log = logging.get_logger(__name__)
 
 
-def is_in_category(channel: disnake.TextChannel, category_id: int) -> bool:
+def is_in_category(channel: discord.TextChannel, category_id: int) -> bool:
     """
     Return whether the given ``channel`` in the the category with the id ``category_id``.
 
@@ -22,22 +22,22 @@ def is_in_category(channel: disnake.TextChannel, category_id: int) -> bool:
     return getattr(channel, "category_id", None) == category_id
 
 
-async def get_or_fetch_channel(bot: Bot, channel_id: int) -> disnake.abc.GuildChannel:
+async def get_or_fetch_channel(bot: Bot, channel_id: int) -> discord.abc.GuildChannel:
     """
     Attempt to get or fetch the given ``channel_id`` from the bots cache, and return it.
 
     Args:
-        bot: The :obj:`disnake.ext.commands.Bot` instance to use for getting/fetching.
+        bot: The :obj:`discord.ext.commands.Bot` instance to use for getting/fetching.
         channel_id: The channel to get/fetch.
 
     Raises:
-        :exc:`disnake.InvalidData`
+        :exc:`discord.InvalidData`
             An unknown channel type was received from Discord.
-        :exc:`disnake.HTTPException`
+        :exc:`discord.HTTPException`
             Retrieving the channel failed.
-        :exc:`disnake.NotFound`
+        :exc:`discord.NotFound`
             Invalid Channel ID.
-        :exc:`disnake.Forbidden`
+        :exc:`discord.Forbidden`
             You do not have permission to fetch this channel.
 
     Returns:

--- a/botcore/utils/extensions.py
+++ b/botcore/utils/extensions.py
@@ -28,7 +28,7 @@ def walk_extensions(module: types.ModuleType) -> frozenset[str]:
         module (types.ModuleType): The module to look for extensions in.
 
     Returns:
-        A set of strings that can be passed directly to :obj:`disnake.ext.commands.Bot.load_extension`.
+        A set of strings that can be passed directly to :obj:`discord.ext.commands.Bot.load_extension`.
     """
 
     def on_error(name: str) -> NoReturn:

--- a/botcore/utils/members.py
+++ b/botcore/utils/members.py
@@ -1,27 +1,27 @@
-"""Useful helper functions for interactin with :obj:`disnake.Member` objects."""
+"""Useful helper functions for interactin with :obj:`discord.Member` objects."""
 
 import typing
 
-import disnake
+import discord
 
 from botcore.utils import logging
 
 log = logging.get_logger(__name__)
 
 
-async def get_or_fetch_member(guild: disnake.Guild, member_id: int) -> typing.Optional[disnake.Member]:
+async def get_or_fetch_member(guild: discord.Guild, member_id: int) -> typing.Optional[discord.Member]:
     """
     Attempt to get a member from cache; on failure fetch from the API.
 
     Returns:
-        The :obj:`disnake.Member` or :obj:`None` to indicate the member could not be found.
+        The :obj:`discord.Member` or :obj:`None` to indicate the member could not be found.
     """
     if member := guild.get_member(member_id):
         log.trace(f"{member} retrieved from cache.")
     else:
         try:
             member = await guild.fetch_member(member_id)
-        except disnake.errors.NotFound:
+        except discord.errors.NotFound:
             log.trace(f"Failed to fetch {member_id} from API.")
             return None
         log.trace(f"{member} fetched from API.")
@@ -29,28 +29,28 @@ async def get_or_fetch_member(guild: disnake.Guild, member_id: int) -> typing.Op
 
 
 async def handle_role_change(
-    member: disnake.Member,
+    member: discord.Member,
     coro: typing.Callable[..., typing.Coroutine],
-    role: disnake.Role
+    role: discord.Role
 ) -> None:
     """
     Await the given ``coro`` with ``member`` as the sole argument.
 
     Handle errors that we expect to be raised from
-    :obj:`disnake.Member.add_roles` and :obj:`disnake.Member.remove_roles`.
+    :obj:`discord.Member.add_roles` and :obj:`discord.Member.remove_roles`.
 
     Args:
         member: The member to pass to ``coro``.
-        coro: This is intended to be :obj:`disnake.Member.add_roles` or :obj:`disnake.Member.remove_roles`.
+        coro: This is intended to be :obj:`discord.Member.add_roles` or :obj:`discord.Member.remove_roles`.
     """
     try:
         await coro(role)
-    except disnake.NotFound:
+    except discord.NotFound:
         log.error(f"Failed to change role for {member} ({member.id}): member not found")
-    except disnake.Forbidden:
+    except discord.Forbidden:
         log.error(
             f"Forbidden to change role for {member} ({member.id}); "
             f"possibly due to role hierarchy"
         )
-    except disnake.HTTPException as e:
+    except discord.HTTPException as e:
         log.error(f"Failed to change role for {member} ({member.id}): {e.status} {e.code}")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,7 @@ extlinks = {
 # -- Options for intersphinx extension ---------------------------------------
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "disnake": ("https://docs.disnake.dev/en/latest/", None),
+    "discord": ("https://discordpy.readthedocs.io/en/master/", None),
     "aiohttp": ("https://docs.aiohttp.org/en/stable/", None),
 }
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -143,22 +143,25 @@ tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
 toml = ["tomli"]
 
 [[package]]
-name = "disnake"
-version = "2.4.0"
+name = "discord.py"
+version = "2.0.0a0"
 description = "A Python wrapper for the Discord API"
 category = "main"
 optional = false
 python-versions = ">=3.8.0"
 
 [package.dependencies]
-aiohttp = ">=3.7.0,<3.9.0"
+aiohttp = ">=3.6.0,<4"
 
 [package.extras]
-discord = ["discord-disnake"]
-docs = ["sphinx (>=4.4.0,<4.5.0)", "sphinxcontrib-trio (==1.1.2)", "sphinx-hoverxref (>=1.0.0,<1.1.0)", "sphinx-autobuild (==2021.3.14)"]
-speed = ["orjson (>=3.5.4)", "aiodns (>=1.1)", "brotli", "cchardet"]
-voice = ["PyNaCl (>=1.3.0,<1.5)"]
+docs = ["sphinx (==4.4.0)", "sphinxcontrib-trio (==1.1.2)", "sphinxcontrib-websupport", "typing-extensions"]
+speed = ["orjson (>=3.5.4)"]
+test = ["coverage", "pytest", "pytest-asyncio", "pytest-cov", "pytest-mock"]
+voice = ["PyNaCl (>=1.3.0,<1.6)"]
 
+[package.source]
+type = "url"
+url = "https://github.com/Rapptz/discord.py/archive/beafaa8a8b8006357c2a1ca6802ed80e000f4cda.zip"
 [[package]]
 name = "distlib"
 version = "0.3.4"
@@ -376,7 +379,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.1"
+version = "4.11.3"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -386,7 +389,7 @@ python-versions = ">=3.7"
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
@@ -889,7 +892,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.13.2"
+version = "20.13.3"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -932,7 +935,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9.*"
-content-hash = "42f5eb3043cb7978b883467bd251b0670265b20676592f9676a462b5a1954847"
+content-hash = "d25465447e76153a71e553297961a960984b8eb32d82a15a00d11958f727499b"
 
 [metadata.files]
 aiohttp = [
@@ -1096,10 +1099,7 @@ coverage = [
     {file = "coverage-6.3.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:18d520c6860515a771708937d2f78f63cc47ab3b80cb78e86573b0a760161faf"},
     {file = "coverage-6.3.2.tar.gz", hash = "sha256:03e2a7826086b91ef345ff18742ee9fc47a6839ccd517061ef8fa1976e652ce9"},
 ]
-disnake = [
-    {file = "disnake-2.4.0-py3-none-any.whl", hash = "sha256:390250a55ed8bbcc8c5753a72fb8fff2376a30295476edfebd0d2301855fb919"},
-    {file = "disnake-2.4.0.tar.gz", hash = "sha256:d7a9c83d5cbfcec42441dae1d96744f82c2a22403934db5d8862a8279ca4989c"},
-]
+"discord.py" = []
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
@@ -1237,8 +1237,8 @@ imagesize = [
     {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.11.1-py3-none-any.whl", hash = "sha256:e0bc84ff355328a4adfc5240c4f211e0ab386f80aa640d1b11f0618a1d282094"},
-    {file = "importlib_metadata-4.11.1.tar.gz", hash = "sha256:175f4ee440a0317f6e8d81b7f8d4869f93316170a65ad2b007d2929186c8052c"},
+    {file = "importlib_metadata-4.11.3-py3-none-any.whl", hash = "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6"},
+    {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1569,8 +1569,8 @@ urllib3 = [
     {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.13.2-py2.py3-none-any.whl", hash = "sha256:e7b34c9474e6476ee208c43a4d9ac1510b041c68347eabfe9a9ea0c86aa0a46b"},
-    {file = "virtualenv-20.13.2.tar.gz", hash = "sha256:01f5f80744d24a3743ce61858123488e91cb2dd1d3bdf92adaf1bba39ffdedf0"},
+    {file = "virtualenv-20.13.3-py2.py3-none-any.whl", hash = "sha256:dd448d1ded9f14d1a4bfa6bfc0c5b96ae3be3f2d6c6c159b23ddcfd701baa021"},
+    {file = "virtualenv-20.13.3.tar.gz", hash = "sha256:e9dd1a1359d70137559034c0f5433b34caf504af2dc756367be86a5a32967134"},
 ]
 yarl = [
     {file = "yarl-1.7.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2a8508f7350512434e41065684076f640ecce176d262a7d54f0da41d99c5a95"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot-core"
-version = "3.0.1"
+version = "4.0.0"
 description = "Bot-Core provides the core functionality and utilities for the bots of the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ exclude = ["tests", "tests.*"]
 
 [tool.poetry.dependencies]
 python = "3.9.*"
-# It is expected that bots that use bot-core will define a striciter version of disnake.
-disnake = "^2"
+"discord.py" = {url = "https://github.com/Rapptz/discord.py/archive/beafaa8a8b8006357c2a1ca6802ed80e000f4cda.zip"}
 
 [tool.poetry.dev-dependencies]
 flake8 = "4.0.1"


### PR DESCRIPTION
This reverts back to discord.py, and bumped the version of discord.py we use up to [this hash](https://github.com/Rapptz/discord.py/commit/beafaa8a8b8006357c2a1ca6802ed80e000f4cda).

This hash was chosen mostly because it's after [my fix](https://github.com/Rapptz/discord.py/pull/7688) so we don't need the extra monkey patch, and there are a few "fix" commits after it (also since it's the HEAD of master right now)