### PR TITLE
Move the creation of BotBase's AsyncResolver to async setup

### DIFF
--- a/botcore/_bot.py
+++ b/botcore/_bot.py
@@ -69,12 +69,8 @@ class BotBase(commands.Bot):
 
         self.api_client: Optional[APIClient] = None
 
-        self._resolver = aiohttp.AsyncResolver()
-        self._connector = aiohttp.TCPConnector(
-            resolver=self._resolver,
-            family=socket.AF_INET,
-        )
-        self.http.connector = self._connector
+        self._resolver: Optional[aiohttp.AsyncResolver] = None
+        self._connector: Optional[aiohttp.TCPConnector] = None
 
         self.statsd_url: Optional[str] = None
         self._statsd_timerhandle: Optional[asyncio.TimerHandle] = None
@@ -212,6 +208,13 @@ class BotBase(commands.Bot):
         and :func:`ping_services`.
         """
         loop = asyncio.get_running_loop()
+
+        self._resolver = aiohttp.AsyncResolver()
+        self._connector = aiohttp.TCPConnector(
+            resolver=self._resolver,
+            family=socket.AF_INET,
+        )
+        self.http.connector = self._connector
 
         self._connect_statsd(self.statsd_url, loop)
         self.stats = AsyncStatsClient(loop, "127.0.0.1")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot-core"
-version = "5.0.0"
+version = "5.0.1"
 description = "Bot-Core provides the core functionality and utilities for the bots of the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"


### PR DESCRIPTION
There is a deprecation notice that this must be created within an async function. This isn't a breaking change.