### PR TITLE
Add unqualify to the utils namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 6.1.0 20th April 2022
+- Feature: Add `unqualify` to the `botcore.utils` namespace for use in bots that manipulate extensions
+
 ## 6.0.0 19th April 2022
 - Breaking: Bump discord.py to [987235d5649e7c2b1a927637bab6547244ecb2cf](https://github.com/Rapptz/discord.py/tree/987235d5649e7c2b1a927637bab6547244ecb2cf)
     - This reverts a change to help command behaviour that broke our custom pagination

--- a/botcore/utils/__init__.py
+++ b/botcore/utils/__init__.py
@@ -1,6 +1,7 @@
 """Useful utilities and tools for Discord bot development."""
 
 from botcore.utils import _monkey_patches, caching, channel, logging, members, regex, scheduling
+from botcore.utils._extensions import unqualify
 
 
 def apply_monkey_patches() -> None:
@@ -27,6 +28,7 @@ __all__ = [
     members,
     regex,
     scheduling,
+    unqualify,
 ]
 
 __all__ = list(map(lambda module: module.__name__, __all__))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bot-core"
-version = "6.0.0"
+version = "6.1.0"
 description = "Bot-Core provides the core functionality and utilities for the bots of the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"


### PR DESCRIPTION
This is for bots that want to use the unqualify function for their own extension cogs