### PR TITLE
Add `clean_text_or_reply` util.

### DIFF
--- a/botcore/utils/__init__.py
+++ b/botcore/utils/__init__.py
@@ -1,6 +1,6 @@
 """Useful utilities and tools for Discord bot development."""
 
-from botcore.utils import _monkey_patches, caching, channel, logging, members, regex, scheduling
+from botcore.utils import _monkey_patches, caching, channel, commands, logging, members, regex, scheduling
 from botcore.utils._extensions import unqualify
 
 
@@ -24,6 +24,7 @@ __all__ = [
     apply_monkey_patches,
     caching,
     channel,
+    commands,
     logging,
     members,
     regex,

--- a/botcore/utils/commands.py
+++ b/botcore/utils/commands.py
@@ -14,7 +14,7 @@ async def clean_text_or_reply(ctx: Context, text: Optional[str] = None) -> str:
 
     Raises:
         :exc:`discord.ext.commands.BadArgument`
-            `text` wasn't provided and there's no reply message.
+            `text` wasn't provided and there's no reply message / reply message content.
 
     Returns:
          The cleaned version of `text`, if given, else replied message.
@@ -28,7 +28,11 @@ async def clean_text_or_reply(ctx: Context, text: Optional[str] = None) -> str:
         (replied_message := getattr(ctx.message.reference, "resolved", None))  # message has a cached reference
         and isinstance(replied_message, Message)  # referenced message hasn't been deleted
     ):
-        return await clean_content_converter.convert(ctx, ctx.message.reference.resolved.content)
+        if not (content := ctx.message.reference.resolved.content):
+            # The referenced message doesn't have a content (e.g. embed/image), so raise error
+            raise BadArgument("The referenced message doesn't have a text content.")
+
+        return await clean_content_converter.convert(ctx, content)
 
     # No text provided, and either no message was referenced or we can't access the content
     raise BadArgument("Couldn't find text to clean. Provide a string or reply to a message to use its content.")

--- a/botcore/utils/commands.py
+++ b/botcore/utils/commands.py
@@ -1,0 +1,21 @@
+from typing import Optional
+
+from discord import Message
+from discord.ext.commands import Context, clean_content
+
+
+async def clean_text_or_reply(ctx: Context, text: Optional[str] = None) -> Optional[str]:
+    """Returns cleaned version of `text`, if given, else referenced message, if found, else `None`."""
+    clean_content_converter = clean_content(fix_channel_mentions=True)
+
+    if text:
+        return await clean_content_converter.convert(ctx, text)
+
+    if (
+        (replied_message := getattr(ctx.message.reference, "resolved", None))  # message has a cached reference
+        and isinstance(replied_message, Message)  # referenced message hasn't been deleted
+    ):
+        return await clean_content_converter.convert(ctx, ctx.message.reference.resolved.content)
+
+    # No text provided, and either no message was referenced or we can't access the content
+    return None

--- a/botcore/utils/commands.py
+++ b/botcore/utils/commands.py
@@ -1,11 +1,24 @@
 from typing import Optional
 
 from discord import Message
-from discord.ext.commands import Context, clean_content
+from discord.ext.commands import BadArgument, Context, clean_content
 
 
-async def clean_text_or_reply(ctx: Context, text: Optional[str] = None) -> Optional[str]:
-    """Returns cleaned version of `text`, if given, else referenced message, if found, else `None`."""
+async def clean_text_or_reply(ctx: Context, text: Optional[str] = None) -> str:
+    """
+    Cleans a text argument or replied message's content.
+
+    Args:
+        ctx: The command's context
+        text: The provided text argument of the command (if given)
+
+    Raises:
+        :exc:`discord.ext.commands.BadArgument`
+            `text` wasn't provided and there's no reply message.
+
+    Returns:
+         The cleaned version of `text`, if given, else replied message.
+    """
     clean_content_converter = clean_content(fix_channel_mentions=True)
 
     if text:
@@ -18,4 +31,4 @@ async def clean_text_or_reply(ctx: Context, text: Optional[str] = None) -> Optio
         return await clean_content_converter.convert(ctx, ctx.message.reference.resolved.content)
 
     # No text provided, and either no message was referenced or we can't access the content
-    return None
+    raise BadArgument("Couldn't find text to clean. Provide a string or reply to a message to use its content.")

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,9 @@
 Changelog
 =========
 
+- :feature:`101` Add a utility to clean a string or referenced message's content
+
+
 - :release:`7.4.0 <17th July 2022>`
 - :feature:`106` Add an optional ``message`` attr to :obj:`botcore.utils.interactions.ViewWithUserAndRoleCheck`. On view timeout, this message has its view removed if set.
 


### PR DESCRIPTION
Closes #100.

Does what the title says.

This util function will clean `text` if provided, else try and clean the referenced message, or if `text` isn't provided and was unable to get a reference message will ~~return `None`~~ raise a BadArgument error, as per [Scaleois' review](https://github.com/python-discord/bot-core/pull/101#discussion_r928096299). 

This is useful for commands such as lancebot's `.uwu` and `.randomcase` where users can either provide a text argument, or reply to a message and have the bot use the replied message's content.

~~NB: Currently a draft as untested~~ Has now been tested so ready for review