### PR TITLE
Correctly determine source modules for re-exported symbols for docs

### DIFF
--- a/docs/utils.py
+++ b/docs/utils.py
@@ -64,6 +64,7 @@ def linkcode_resolve(repo_link: str, domain: str, info: dict[str, str]) -> typin
 
     try:
         lines, start = inspect.getsourcelines(symbol[-1])
+        module = inspect.getmodule(symbol[-1])
         end = start + len(lines)
     except TypeError:
         # Find variables by parsing the ast


### PR DESCRIPTION
Closes: #80 

In some cases, the origin module of symbols as seen by sphinx doesn't correspond to the actual module they are defined in, this PR makes sure we grab the module where the object is defined in if it's an object we can determine that for. 