### PR TITLE
Bump poetry to 1.2.0 in CI & the example project

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,10 +27,6 @@ jobs:
           python_version: "3.10"
           install_args: "--extras async-rediscache"
 
-      # Undeclared dependency for `releases`... whoops
-      # https://github.com/bitprophet/releases/pull/82
-      - run: pip install six
-
       - name: Generate HTML Site
         run: sphinx-build -nW -j auto -b html docs docs/build
 
@@ -55,10 +51,6 @@ jobs:
           dev: true
           python_version: "3.10"
           install_args: "--extras async-rediscache"
-
-      # Undeclared dependency for `releases`... whoops
-      # https://github.com/bitprophet/releases/pull/82
-      - run: pip install six
 
       - name: Build All Doc Versions
         run: sphinx-multiversion docs docs/build -n -j auto

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,7 +11,6 @@ concurrency:
   group: docs-deployment-${{ github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   latest-build:
     # We only need to verify that the docs build with no warnings here
@@ -22,7 +21,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Python Dependencies
-        uses: HassanAbouelela/actions/setup-python@setup-python_v1.1.0
+        uses: HassanAbouelela/actions/setup-python@setup-python_v1.3.1
         with:
           dev: true
           python_version: "3.10"
@@ -51,7 +50,7 @@ jobs:
           fetch-depth: 0  # We need to check out the entire repository to find all tags
 
       - name: Install Python Dependencies
-        uses: HassanAbouelela/actions/setup-python@setup-python_v1.1.0
+        uses: HassanAbouelela/actions/setup-python@setup-python_v1.3.1
         with:
           dev: true
           python_version: "3.10"

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -24,10 +24,9 @@ jobs:
           install_args: "--extras async-rediscache"
 
       # We will not run `flake8` here, as we will use a separate flake8
-      # action. As pre-commit does not support user installs, we set
-      # PIP_USER=0 to not do a user install.
+      # action.
       - name: Run pre-commit hooks
-        run: export PIP_USER=0; SKIP=flake8 pre-commit run --all-files
+        run: SKIP=flake8 pre-commit run --all-files
 
       # Run flake8 and have it format the linting errors in the format of
       # the GitHub Workflow command to register error annotations. This

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,10 +14,9 @@ jobs:
   lint:
     name: Run Linting & Test Suites
     runs-on: ubuntu-latest
-
     steps:
       - name: Install Python Dependencies
-        uses: HassanAbouelela/actions/setup-python@setup-python_v1.1.0
+        uses: HassanAbouelela/actions/setup-python@setup-python_v1.3.1
         with:
           # Set dev=true to run pre-commit which is a dev dependency
           dev: true

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,26 +1,8 @@
-FROM --platform=linux/amd64 python:3.10-slim
+FROM --platform=linux/amd64 ghcr.io/chrislovering/python-poetry-base:3.10-slim
 
-# Set pip to have no saved cache
-ENV PIP_NO_CACHE_DIR=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=on \
-    POETRY_VERSION=1.2.0 \
-    POETRY_HOME="/opt/poetry" \
-    POETRY_VIRTUALENVS_IN_PROJECT=true \
-    POETRY_NO_INTERACTION=1 \
-    APP_DIR="/app"
-
-ENV PATH="$POETRY_HOME/bin:/$APP_DIR/.venv/bin:$PATH"
-
-# Install poetry
-RUN apt-get update \
-  && apt-get -y upgrade \
-  && apt-get install --no-install-recommends -y curl \
-  && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN curl -sSL https://install.python-poetry.org | python
 
 # Install project dependencies
-WORKDIR $APP_DIR
+WORKDIR /app
 COPY pyproject.toml poetry.lock ./
 RUN poetry install --no-root
 

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,20 +1,32 @@
-FROM python:3.10-slim
+FROM --platform=linux/amd64 python:3.10-slim
 
 # Set pip to have no saved cache
-ENV PIP_NO_CACHE_DIR=false \
-    POETRY_VIRTUALENVS_CREATE=false
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=on \
+    POETRY_VERSION=1.2.0 \
+    POETRY_HOME="/opt/poetry" \
+    POETRY_VIRTUALENVS_IN_PROJECT=true \
+    POETRY_NO_INTERACTION=1 \
+    APP_DIR="/app"
+
+ENV PATH="$POETRY_HOME/bin:/$APP_DIR/.venv/bin:$PATH"
 
 # Install poetry
-RUN pip install -U poetry
+RUN apt-get update \
+  && apt-get -y upgrade \
+  && apt-get install --no-install-recommends -y curl \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /app
+RUN curl -sSL https://install.python-poetry.org | python
 
 # Install project dependencies
+WORKDIR $APP_DIR
 COPY pyproject.toml poetry.lock ./
 RUN poetry install --no-root
 
 # Copy the source code in last to optimize rebuilding the image
 COPY . .
+
 # Install again, this time with the root project
 RUN poetry install
 

--- a/dev/README.rst
+++ b/dev/README.rst
@@ -40,7 +40,7 @@ Option 2
 3. Configure the environment variables used by the program.
    You can set them in an ``.env`` file in the project root directory. The variables are:
 
-   - ``TOKEN`` (required): Discord bot token, with all intents enabled
+   - ``BOT_TOKEN`` (required): Discord bot token, with all intents enabled
    - ``GUILD_ID`` (required): The guild the bot should monitor
    - ``PREFIX``: The prefix to use for invoking bot commands. Defaults to mentions and ``!``
    - ``ALLOWED_ROLES``: A comma seperated list of role IDs which the bot is allowed to mention

--- a/dev/bot/__main__.py
+++ b/dev/bot/__main__.py
@@ -29,6 +29,6 @@ async def main() -> None:
     """Run the bot."""
     bot.http_session = aiohttp.ClientSession()
     async with bot:
-        await bot.start(os.getenv("TOKEN"))
+        await bot.start(os.getenv("BOT_TOKEN"))
 
 asyncio.run(main())

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -68,8 +68,9 @@ services:
     build:
       context: .
       dockerfile: dev/Dockerfile
-    volumes:
-      - .:/app:ro
+    volumes:  # Don't do .:/app here to ensure project venv from host doens't overwrite venv in image
+      - ./botcore:/app/botcore:ro
+      - ./bot:/app/bot:ro
     tty: true
     depends_on:
       - web

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,20 @@ services:
       timeout: 1s
       retries: 5
 
+  metricity:
+    restart: on-failure
+    depends_on:
+      postgres:
+        condition: service_healthy
+    image: ghcr.io/python-discord/metricity:latest
+    env_file:
+      - .env
+    environment:
+      DATABASE_URI: postgres://pysite:pysite@postgres/metricity
+      USE_METRICITY: ${USE_METRICITY-false}
+    volumes:
+      - .:/tmp/bot:ro
+
   redis:
     << : *restart_policy
     image: redis:5.0.9
@@ -46,6 +60,8 @@ services:
       METRICITY_DB_URL: postgres://pysite:pysite@postgres:5432/metricity
       SECRET_KEY: suitable-for-development-only
       STATIC_ROOT: /var/www/static
+    depends_on:
+      - metricity
 
   bot:
     << : *restart_policy
@@ -55,6 +71,8 @@ services:
     volumes:
       - .:/app:ro
     tty: true
+    depends_on:
+      - web
     env_file:
       - .env
     environment:


### PR DESCRIPTION
The change to 1.2.0 requires the use of in-project venvs, rather than pip user installs. This changes how the project is laid out, hence the Dockerfile & compose changes.

Changelog:
![image](https://user-images.githubusercontent.com/9753350/189499997-ea7fd798-0bb7-4390-a5e8-77e96261aad3.png)
