### PR TITLE
Add `check_rerun_job` util to commands.py

### DIFF
--- a/botcore/utils/commands.py
+++ b/botcore/utils/commands.py
@@ -1,7 +1,13 @@
+from asyncio import TimeoutError
+from contextlib import suppress
 from typing import Optional
 
-from discord import Message
+from discord import HTTPException, Message, NotFound
 from discord.ext.commands import BadArgument, Context, clean_content
+
+
+REDO_EMOJI = '\U0001f501'  # :repeat:
+REDO_TIMEOUT = 30
 
 
 async def clean_text_or_reply(ctx: Context, text: Optional[str] = None) -> str:
@@ -36,3 +42,57 @@ async def clean_text_or_reply(ctx: Context, text: Optional[str] = None) -> str:
 
     # No text provided, and either no message was referenced or we can't access the content
     raise BadArgument("Couldn't find text to clean. Provide a string or reply to a message to use its content.")
+
+
+async def check_rerun_job(ctx: Context, response: Message) -> Optional[str]:
+    """
+    Check if the job should be rerun.
+
+    For a job to be rerun, the user must edit their message within `REDO_TIMEOUT` seconds,
+    and then react with the `REDO_EMOJI` within 10 seconds.
+
+    Args:
+        ctx: The command's context
+        response: The job's response message
+
+    Returns:
+         The content to be rerun, or `None`.
+    """
+    # Correct message and content did actually change (i.e. wasn't a pin status udpate etc.)
+    _message_edit_predicate = lambda old, new: new.id == ctx.message.id and new.content != old.content
+
+    _reaction_add_predicate = lambda reaction, user: all((
+        user.id == ctx.author.id,  # correct user
+        str(reaction) == REDO_EMOJI,  # correct emoji
+        reaction.message.id == ctx.message.id  # correct message
+    ))
+
+    with suppress(NotFound):
+        try:
+            _, new_message = await ctx.bot.wait_for(
+                'message_edit',
+                check=_message_edit_predicate,
+                timeout=REDO_TIMEOUT
+            )
+            await ctx.message.add_reaction(REDO_EMOJI)
+
+            await ctx.bot.wait_for(
+                'reaction_add',
+                check=_reaction_add_predicate,
+                timeout=10
+            )
+
+            await ctx.message.clear_reaction(REDO_EMOJI)
+            with suppress(HTTPException):
+                await response.delete()
+
+        except TimeoutError:
+            # One of the `wait_for` timed out, so abort since user doesn't want to rerun
+            await ctx.message.clear_reaction(REDO_EMOJI)
+            return None
+
+        else:
+            # Both `wait_for` triggered, so return the new content to be run since user wants to rerun
+            return new_message.content
+
+    return None  # triggered whenever a `NotFound` was raised


### PR DESCRIPTION
Uses the logic of the eval command in [python-discord/bot](https://github.com/python-discord/bot) to create a re-run util.

That is, if the passed context's message content is edited within `REDO_TIMEOUT` seconds, and the user then reacts with the 🔁 emoji that appears, then the util will return the new content, indicating that the job should be re-run. Otherwise, `None` is returned, indicating the job shouldn't be re-run.

This is made since python-discord/sir-lancebot#1062 asks for re-run, and since the logic is essentially already in bot I'm moving to bot-core to avoid duplicate code (as per approval from @mbaruh in the staff-lounge).


*Opened as a draft until I've tested.*