### PR TITLE
Return null None from get_or_fetch_member upon unfound members & bad requests 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,9 @@
 Changelog
 =========
 
+- :release:`9.3.0 <13th December 2022>`
+- :feature:`169` Return None upon sending a bad request to fetch a member
+
 - :release:`9.2.0 <17th November 2022>`
 - :support:`151` Add support for Python 3.11
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 =========
 
 - :release:`9.3.0 <13th December 2022>`
-- :feature:`169` Return None upon sending a bad request to fetch a member
+- :feature:`169` Return :obj:`None` upon receiving a bad request from Discord in :obj:`pydis_core.utils.members.get_or_fetch_member`
 
 - :release:`9.2.0 <17th November 2022>`
 - :support:`151` Add support for Python 3.11

--- a/pydis_core/utils/members.py
+++ b/pydis_core/utils/members.py
@@ -18,13 +18,15 @@ async def get_or_fetch_member(guild: discord.Guild, member_id: int) -> typing.Op
     """
     if member := guild.get_member(member_id):
         log.trace(f"{member} retrieved from cache.")
-    else:
-        try:
-            member = await guild.fetch_member(member_id)
-        except discord.errors.NotFound:
-            log.trace(f"Failed to fetch {member_id} from API.")
+        return member
+    try:
+        member = await guild.fetch_member(member_id)
+    except discord.errors.HTTPException as e:
+        log.trace(f"Failed to fetch {member_id} from API.")
+        if e.status in [400, 404]:
             return None
-        log.trace(f"{member} fetched from API.")
+        raise
+    log.trace(f"{member} fetched from API.")
     return member
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydis_core"
-version = "9.2.0"
+version = "9.3.0"
 description = "PyDis core provides core functionality and utility to the bots of the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"


### PR DESCRIPTION
closes #152 

Instead of returning a null member instance upon `NotFound` exceptions, we've also decided to do the same for all bad requests, e.g. 400 status codes. 