### PR TITLE
Sync global and guild app command tree on startup

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,9 @@
 Changelog
 =========
 
+- :release:`9.4.0 <24th December 2022>`
+- :feature:`171` Sync all app commands after extensions have been loaded. This release also removes the need to run :obj:`pydis_core.BotBase.load_extensions` in a task.
+
 
 - :release:`9.3.1 <23rd December 2022>`
 - :bug:`170` Save references of newly created tasks in :obj:`pydis_core.utils.scheduling`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydis_core"
-version = "9.3.1"
+version = "9.4.0"
 description = "PyDis core provides core functionality and utility to the bots of the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"


### PR DESCRIPTION
This change syncs all app commands after extensions have been loaded.

This release also removes the need to run :obj:`pydis_core.BotBase.load_extensions` in a task, and it can just be awaited directly.

A beta release for this PR is available under `9.4.0b1` on pypi.

Changelog preview:
![image](https://user-images.githubusercontent.com/9753350/209442523-c421c14a-2f1f-4443-8984-31896b65ffd6.png)

Docstring:
![image](https://user-images.githubusercontent.com/9753350/209568359-a1a49d82-057b-4fcf-925e-704fa6ed19af.png)

## Approach
I specifically decided to go with a on-startup sync, rather than command based as it does not require us to manually call a command after merging a PR with a new/update to an app command.

There is a ratelimit on syncing global commands which add new commands (200 commands per guild per day), however updating commands (currently) has no ratelimit.