### PR TITLE
Bump discord.py to 2.1.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 =========
 
 - :release:`9.4.1 <9th February 2023>`
-- :feature:`158` Bump Discord.py to :literal-url:`2.1.0 <https://github.com/Rapptz/discord.py/releases/tag/v2.1.0>`.
+- :feature:`172` Bump Discord.py to :literal-url:`2.1.1 <https://github.com/Rapptz/discord.py/releases/tag/v2.1.1>`.
 
 
 - :release:`9.4.0 <24th December 2022>`
@@ -13,7 +13,7 @@ Changelog
 
 
 - :release:`9.3.1 <23rd December 2022>`
-- :bug:`172` Bump discord.py to :literal-url:`2.1.1 <https://github.com/Rapptz/discord.py/releases/tag/v2.1.1>`.
+- :bug:`170` Save references of newly created tasks in :obj:`pydis_core.utils.scheduling`
 
 - :release:`9.3.0 <13th December 2022>`
 - :feature:`169` Return :obj:`None` upon receiving a bad request from Discord in :obj:`pydis_core.utils.members.get_or_fetch_member`

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,12 +4,16 @@
 Changelog
 =========
 
+- :release:`9.4.1 <9th February 2023>`
+- :feature:`158` Bump Discord.py to :literal-url:`2.1.0 <https://github.com/Rapptz/discord.py/releases/tag/v2.1.0>`.
+
+
 - :release:`9.4.0 <24th December 2022>`
 - :feature:`171` Sync all app commands after extensions have been loaded. This release also removes the need to run :obj:`pydis_core.BotBase.load_extensions` in a task.
 
 
 - :release:`9.3.1 <23rd December 2022>`
-- :bug:`170` Save references of newly created tasks in :obj:`pydis_core.utils.scheduling`
+- :bug:`172` Bump discord.py to :literal-url:`2.1.1 <https://github.com/Rapptz/discord.py/releases/tag/v2.1.1>`.
 
 - :release:`9.3.0 <13th December 2022>`
 - :feature:`169` Return :obj:`None` upon receiving a bad request from Discord in :obj:`pydis_core.utils.members.get_or_fetch_member`

--- a/poetry.lock
+++ b/poetry.lock
@@ -173,7 +173,7 @@ toml = ["tomli"]
 
 [[package]]
 name = "discord-py"
-version = "2.1.0"
+version = "2.1.1"
 description = "A Python wrapper for the Discord API"
 category = "main"
 optional = false
@@ -1059,7 +1059,7 @@ async-rediscache = ["async-rediscache"]
 [metadata]
 lock-version = "1.1"
 python-versions = "3.10.* || 3.11.*"
-content-hash = "f8b98393f7a10f019afb94260f87e92280533dda4057e9f7799dcd64512e13f2"
+content-hash = "fe3aeba2ea2997b9f328e1b0289b18d90920287df0854e5e84900091d25eedb3"
 
 [metadata.files]
 aiodns = [
@@ -1318,8 +1318,8 @@ coverage = [
     {file = "coverage-6.5.0.tar.gz", hash = "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84"},
 ]
 discord-py = [
-    {file = "discord.py-2.1.0-py3-none-any.whl", hash = "sha256:a2cfa9f09e3013aaaa43600cc8dfaf67c532dd34afcb71e550f5a0dc9133a5e0"},
-    {file = "discord.py-2.1.0.tar.gz", hash = "sha256:027ccdd22b5bb66a9e19cbd8daa1bc74b49271a16a074d57e52f288fcfa208e8"},
+    {file = "discord.py-2.1.1-py3-none-any.whl", hash = "sha256:b99fbf4ad74f007c680f33f5174738858146c99a2bc4f6d0e08ddbf93bc12c4d"},
+    {file = "discord.py-2.1.1.tar.gz", hash = "sha256:8258b7af641c532e9e33e186c7b867d9ff5575fe63a460b17ed55bd4fe082200"},
 ]
 distlib = [
     {file = "distlib-0.3.6-py2.py3-none-any.whl", hash = "sha256:f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydis_core"
-version = "9.4.0"
+version = "9.4.1"
 description = "PyDis core provides core functionality and utility to the bots of the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ keywords = ["bot", "discord", "discord.py"]
 [tool.poetry.dependencies]
 python = "3.10.* || 3.11.*"
 
-"discord.py" = "2.1.0"
+"discord.py" = "2.1.1"
 async-rediscache = { version = "1.0.0rc2", extras = ["fakeredis"], optional = true }
 statsd  = "4.0.1"
 aiodns = "3.0.0"


### PR DESCRIPTION
Per [discussion in `#dev-contrib`](https://discord.com/channels/267624335836053506/635950537262759947/1073324647556329476), `discord.py` was not prepared for animated stickers, and sending one causes bots to die.

`discord.py` has this patched already, and they just released this patch in their `2.1.1` release.
Release notice: https://discord.com/channels/336642139381301249/381965829857738772/1073356192551796813 (`discord.py` `#updates`)
