### PR TITLE
Update expiry label from 1 month to 30 days

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,7 +3,11 @@
 
 Changelog
 =========
-- :release:`9.9.0 <22th June 2023>`
+- :release:`9.9.2 <2nd July 2023>`
+- :bug:`185` Update expiry label from 1 month to 30 days in paste service.
+
+
+- :release:`9.9.1 <22nd June 2023>`
 - :bug:`183` Push the correct changeset to pypi.
 
 

--- a/pydis_core/utils/paste_service.py
+++ b/pydis_core/utils/paste_service.py
@@ -90,7 +90,7 @@ async def send_to_paste_service(
 
     log.debug(f"Sending contents of size {contents_size} bytes to paste service.")
     payload = {
-        "expiry": "1month",
+        "expiry": "30days",
         "long": "on",  # Use a longer URI for the paste.
         "files": [
             {"name": file_name, "lexer": lexer, "content": contents},


### PR DESCRIPTION
Since there isn't 1 true answer to how many seconds are in 1 month, making it 30 days is just easier.