### PR TITLE
Update get_or_fetch_channel's return type

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,9 @@
 
 Changelog
 =========
+
+- :bug:`187` Fix :obj:`pydis_core.utils.channel.get_or_fetch_channel`'s return type to include :obj:`discord.abc.PrivateChannel` and :obj:`discord.Thread`.
+
 - :release:`9.9.2 <2nd July 2023>`
 - :bug:`185` Update expiry label from 1 month to 30 days in paste service.
 

--- a/pydis_core/utils/channel.py
+++ b/pydis_core/utils/channel.py
@@ -23,8 +23,8 @@ def is_in_category(channel: discord.TextChannel, category_id: int) -> bool:
 
 
 async def get_or_fetch_channel(
-        bot: Bot,
-        channel_id: int
+    bot: Bot,
+    channel_id: int,
 ) -> discord.abc.GuildChannel | discord.abc.PrivateChannel | discord.Thread:
     """
     Attempt to get or fetch the given ``channel_id`` from the bots cache, and return it.

--- a/pydis_core/utils/channel.py
+++ b/pydis_core/utils/channel.py
@@ -22,7 +22,10 @@ def is_in_category(channel: discord.TextChannel, category_id: int) -> bool:
     return getattr(channel, "category_id", None) == category_id
 
 
-async def get_or_fetch_channel(bot: Bot, channel_id: int) -> discord.abc.GuildChannel:
+async def get_or_fetch_channel(
+        bot: Bot,
+        channel_id: int
+) -> discord.abc.GuildChannel | discord.abc.PrivateChannel | discord.Thread:
     """
     Attempt to get or fetch the given ``channel_id`` from the bots cache, and return it.
 


### PR DESCRIPTION
The `get_or_fetch_channel` util has missing return types, namely `discord.abc.PrivateChannel` and `discord.Thread`.

These are needed to ensure type hinting is correct in upstream projects.