### PR TITLE
Block fixup commits

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,5 +13,11 @@ concurrency:
 jobs:
   lint-test:
     uses: ./.github/workflows/lint-test.yaml
+
+  fixup-commit-blocker:
+    if: github.ref != 'refs/heads/main'
+    uses: python-discord/.github/.github/workflows/block-fixup-commits.yaml@main
+    needs: lint-test
+
   docs:
     uses: ./.github/workflows/docs.yaml


### PR DESCRIPTION
This uses the organisation's fixup commit blocker workflow.

The purpose is to make sure all commits prefixed with `fixup` need to be squashed before merging.