### PR TITLE
Migrate test helpers to bot-core

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ Changelog
 =========
 
 
+- :release:`10.3.0 <29th August 2023>`
+- :support:`193` Migrate testing helpers from bot repo.
+
+
 - :release:`10.2.0 <28th August 2023>`
 - :support:`192` Bump Discord.py to :literal-url:`2.3.2 <https://github.com/Rapptz/discord.py/releases/tag/v2.3.2>`.
 

--- a/pydis_core/utils/tests/__init__.py
+++ b/pydis_core/utils/tests/__init__.py
@@ -1,0 +1,8 @@
+from pydis_core.utils.tests import base, helpers
+
+__all__ = [
+    base,
+    helpers
+]
+
+__all__ = [module.__name__ for module in __all__]

--- a/pydis_core/utils/tests/_autospec.py
+++ b/pydis_core/utils/tests/_autospec.py
@@ -1,0 +1,65 @@
+import contextlib
+import functools
+import pkgutil
+import unittest.mock
+from collections.abc import Callable
+
+
+@functools.wraps(unittest.mock._patch.decoration_helper)
+@contextlib.contextmanager
+def _decoration_helper(self, patched, args, keywargs):
+    """Skips adding patchings as args if their `dont_pass` attribute is True."""
+    # Don't ask what this does. It's just a copy from stdlib, but with the dont_pass check added.
+    extra_args = []
+    with contextlib.ExitStack() as exit_stack:
+        for patching in patched.patchings:
+            arg = exit_stack.enter_context(patching)
+            if not getattr(patching, "dont_pass", False):
+                # Only add the patching as an arg if dont_pass is False.
+                if patching.attribute_name is not None:
+                    keywargs.update(arg)
+                elif patching.new is unittest.mock.DEFAULT:
+                    extra_args.append(arg)
+
+        args += tuple(extra_args)
+        yield args, keywargs
+
+
+@functools.wraps(unittest.mock._patch.copy)
+def _copy(self):
+    """Copy the `dont_pass` attribute along with the standard copy operation."""
+    patcher_copy = _copy.original(self)
+    patcher_copy.dont_pass = getattr(self, "dont_pass", False)
+    return patcher_copy
+
+
+# Monkey-patch the patcher class :)
+_copy.original = unittest.mock._patch.copy
+unittest.mock._patch.copy = _copy
+unittest.mock._patch.decoration_helper = _decoration_helper
+
+
+def autospec(target, *attributes: str, pass_mocks: bool = True, **patch_kwargs) -> Callable:
+    """
+    Patch multiple `attributes` of a `target` with autospecced mocks and `spec_set` as True.
+
+    If `pass_mocks` is True, pass the autospecced mocks as arguments to the decorated object.
+    """
+    # Caller's kwargs should take priority and overwrite the defaults.
+    kwargs = dict(spec_set=True, autospec=True)
+    kwargs.update(patch_kwargs)
+
+    # Import the target if it's a string.
+    # This is to support both object and string targets like patch.multiple.
+    if isinstance(target, str):
+        target = pkgutil.resolve_name(target)
+
+    def decorator(func):
+        for attribute in attributes:
+            patcher = unittest.mock.patch.object(target, attribute, **kwargs)
+            if not pass_mocks:
+                # A custom attribute to keep track of which patchings should be skipped.
+                patcher.dont_pass = True
+            func = patcher(func)
+        return func
+    return decorator

--- a/pydis_core/utils/tests/base.py
+++ b/pydis_core/utils/tests/base.py
@@ -1,0 +1,129 @@
+import logging
+import unittest
+from contextlib import contextmanager
+
+import discord
+from async_rediscache import RedisSession
+from discord.ext import commands
+
+from bot.log import get_logger
+from tests import helpers
+
+
+class _CaptureLogHandler(logging.Handler):
+    """
+    A logging handler capturing all (raw and formatted) logging output.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+class LoggingTestsMixin:
+    """
+    A mixin that defines additional test methods for logging behavior.
+
+    This mixin relies on the availability of the `fail` attribute defined by the
+    test classes included in Python's unittest method to signal test failure.
+    """
+
+    @contextmanager
+    def assertNotLogs(self, logger=None, level=None, msg=None):  # noqa: N802
+        """
+        Asserts that no logs of `level` and higher were emitted by `logger`.
+
+        You can specify a specific `logger`, the minimum `logging` level we want to watch and a
+        custom `msg` to be added to the `AssertionError` if thrown. If the assertion fails, the
+        recorded log records will be outputted with the `AssertionError` message. The context
+        manager does not yield a live `look` into the logging records, since we use this context
+        manager when we're testing under the assumption that no log records will be emitted.
+        """
+        if not isinstance(logger, logging.Logger):
+            logger = get_logger(logger)
+
+        if level:
+            level = logging._nameToLevel.get(level, level)
+        else:
+            level = logging.INFO
+
+        handler = _CaptureLogHandler()
+        old_handlers = logger.handlers[:]
+        old_level = logger.level
+        old_propagate = logger.propagate
+
+        logger.handlers = [handler]
+        logger.setLevel(level)
+        logger.propagate = False
+
+        try:
+            yield
+        except Exception as exc:
+            raise exc
+        finally:
+            logger.handlers = old_handlers
+            logger.propagate = old_propagate
+            logger.setLevel(old_level)
+
+        if handler.records:
+            level_name = logging.getLevelName(level)
+            n_logs = len(handler.records)
+            base_message = f"{n_logs} logs of {level_name} or higher were triggered on {logger.name}:\n"
+            records = [str(record) for record in handler.records]
+            record_message = "\n".join(records)
+            standard_message = self._truncateMessage(base_message, record_message)
+            msg = self._formatMessage(msg, standard_message)
+            self.fail(msg)
+
+
+class CommandTestCase(unittest.IsolatedAsyncioTestCase):
+    """TestCase with additional assertions that are useful for testing Discord commands."""
+
+    async def assertHasPermissionsCheck(  # noqa: N802
+        self,
+        cmd: commands.Command,
+        permissions: dict[str, bool],
+    ) -> None:
+        """
+        Test that `cmd` raises a `MissingPermissions` exception if author lacks `permissions`.
+
+        Every permission in `permissions` is expected to be reported as missing. In other words, do
+        not include permissions which should not raise an exception along with those which should.
+        """
+        # Invert permission values because it's more intuitive to pass to this assertion the same
+        # permissions as those given to the check decorator.
+        permissions = {k: not v for k, v in permissions.items()}
+
+        ctx = helpers.MockContext()
+        ctx.channel.permissions_for.return_value = discord.Permissions(**permissions)
+
+        with self.assertRaises(commands.MissingPermissions) as cm:
+            await cmd.can_run(ctx)
+
+        self.assertCountEqual(permissions.keys(), cm.exception.missing_permissions)
+
+
+class RedisTestCase(unittest.IsolatedAsyncioTestCase):
+    """
+    Use this as a base class for any test cases that require a redis session.
+
+    This will prepare a fresh redis instance for each test function, and will
+    not make any assertions on its own. Tests can mutate the instance as they wish.
+    """
+
+    session = None
+
+    async def flush(self):
+        """Flush everything from the redis database to prevent carry-overs between tests."""
+        await self.session.client.flushall()
+
+    async def asyncSetUp(self):
+        self.session = await RedisSession(use_fakeredis=True).connect()
+        await self.flush()
+
+    async def asyncTearDown(self):
+        if self.session:
+            await self.session.client.close()

--- a/pydis_core/utils/tests/base.py
+++ b/pydis_core/utils/tests/base.py
@@ -1,14 +1,21 @@
 import logging
 import unittest
+import warnings
 from contextlib import contextmanager
 
 import discord
-from async_rediscache import RedisSession
-from bot.log import get_logger
 from discord.ext import commands
 
-from tests import helpers
+from pydis_core.utils.logging import get_logger
 
+from . import helpers
+
+try:
+    from async_rediscache import RedisSession
+    REDIS_AVAILABLE = True
+except ImportError:
+    RedisSession = object
+    REDIS_AVAILABLE = False
 
 class _CaptureLogHandler(logging.Handler):
     """A logging handler capturing all (raw and formatted) logging output."""
@@ -119,6 +126,8 @@ class RedisTestCase(unittest.IsolatedAsyncioTestCase):
         await self.session.client.flushall()
 
     async def asyncSetUp(self):
+        if not REDIS_AVAILABLE:
+            warnings.warn("redis_session kwarg passed, but async-rediscache not installed!", stacklevel=2)
         self.session = await RedisSession(use_fakeredis=True).connect()
         await self.flush()
 

--- a/pydis_core/utils/tests/base.py
+++ b/pydis_core/utils/tests/base.py
@@ -4,16 +4,14 @@ from contextlib import contextmanager
 
 import discord
 from async_rediscache import RedisSession
+from bot.log import get_logger
 from discord.ext import commands
 
-from bot.log import get_logger
 from tests import helpers
 
 
 class _CaptureLogHandler(logging.Handler):
-    """
-    A logging handler capturing all (raw and formatted) logging output.
-    """
+    """A logging handler capturing all (raw and formatted) logging output."""
 
     def __init__(self):
         super().__init__()

--- a/pydis_core/utils/tests/helpers.py
+++ b/pydis_core/utils/tests/helpers.py
@@ -1,0 +1,676 @@
+from __future__ import annotations
+
+import collections
+import itertools
+import logging
+import unittest.mock
+from asyncio import AbstractEventLoop
+from collections.abc import Iterable
+from contextlib import contextmanager
+from functools import cached_property
+
+import discord
+from aiohttp import ClientSession
+from discord.ext.commands import Context
+from pydis_core.async_stats import AsyncStatsClient
+from pydis_core.site_api import APIClient
+
+from bot.bot import Bot
+from tests._autospec import autospec  # noqa: F401 other modules import it via this module
+
+for logger in logging.Logger.manager.loggerDict.values():
+    # Set all loggers to CRITICAL by default to prevent screen clutter during testing
+
+    if not isinstance(logger, logging.Logger):
+        # There might be some logging.PlaceHolder objects in there
+        continue
+
+    logger.setLevel(logging.CRITICAL)
+
+
+class HashableMixin(discord.mixins.EqualityComparable):
+    """
+    Mixin that provides similar hashing and equality functionality as discord.py's `Hashable` mixin.
+
+    Note: discord.py`s `Hashable` mixin bit-shifts `self.id` (`>> 22`); to prevent hash-collisions
+    for the relative small `id` integers we generally use in tests, this bit-shift is omitted.
+    """
+
+    def __hash__(self):
+        return self.id
+
+
+class ColourMixin:
+    """A mixin for Mocks that provides the aliasing of (accent_)color->(accent_)colour like discord.py does."""
+
+    @property
+    def color(self) -> discord.Colour:
+        return self.colour
+
+    @color.setter
+    def color(self, color: discord.Colour) -> None:
+        self.colour = color
+
+    @property
+    def accent_color(self) -> discord.Colour:
+        return self.accent_colour
+
+    @accent_color.setter
+    def accent_color(self, color: discord.Colour) -> None:
+        self.accent_colour = color
+
+
+class CustomMockMixin:
+    """
+    Provides common functionality for our custom Mock types.
+
+    The `_get_child_mock` method automatically returns an AsyncMock for coroutine methods of the mock
+    object. As discord.py also uses synchronous methods that nonetheless return coroutine objects, the
+    class attribute `additional_spec_asyncs` can be overwritten with an iterable containing additional
+    attribute names that should also mocked with an AsyncMock instead of a regular MagicMock/Mock. The
+    class method `spec_set` can be overwritten with the object that should be uses as the specification
+    for the mock.
+
+    Mock/MagicMock subclasses that use this mixin only need to define `__init__` method if they need to
+    implement custom behavior.
+    """
+
+    child_mock_type = unittest.mock.MagicMock
+    discord_id = itertools.count(0)
+    spec_set = None
+    additional_spec_asyncs = None
+
+    def __init__(self, **kwargs):
+        name = kwargs.pop("name", None)  # `name` has special meaning for Mock classes, so we need to set it manually.
+        super().__init__(spec_set=self.spec_set, **kwargs)
+
+        if self.additional_spec_asyncs:
+            self._spec_asyncs.extend(self.additional_spec_asyncs)
+
+        if name:
+            self.name = name
+
+    def _get_child_mock(self, **kw):
+        """
+        Overwrite of the `_get_child_mock` method to stop the propagation of our custom mock classes.
+
+        Mock objects automatically create children when you access an attribute or call a method on them. By default,
+        the class of these children is the type of the parent itself. However, this would mean that the children created
+        for our custom mock types would also be instances of that custom mock type. This is not desirable, as attributes
+        of, e.g., a `Bot` object are not `Bot` objects themselves. The Python docs for `unittest.mock` hint that
+        overwriting this method is the best way to deal with that.
+
+        This override will look for an attribute called `child_mock_type` and use that as the type of the child mock.
+        """
+        _new_name = kw.get("_new_name")
+        if _new_name in self.__dict__["_spec_asyncs"]:
+            return unittest.mock.AsyncMock(**kw)
+
+        _type = type(self)
+        if issubclass(_type, unittest.mock.MagicMock) and _new_name in unittest.mock._async_method_magics:
+            # Any asynchronous magic becomes an AsyncMock
+            klass = unittest.mock.AsyncMock
+        else:
+            klass = self.child_mock_type
+
+        if self._mock_sealed:
+            attribute = "." + kw["name"] if "name" in kw else "()"
+            mock_name = self._extract_mock_name() + attribute
+            raise AttributeError(mock_name)
+
+        return klass(**kw)
+
+
+# Create a guild instance to get a realistic Mock of `discord.Guild`
+guild_data = {
+    "id": 1,
+    "name": "guild",
+    "region": "Europe",
+    "verification_level": 2,
+    "default_notications": 1,
+    "afk_timeout": 100,
+    "icon": "icon.png",
+    "banner": "banner.png",
+    "mfa_level": 1,
+    "splash": "splash.png",
+    "system_channel_id": 464033278631084042,
+    "description": "mocking is fun",
+    "max_presences": 10_000,
+    "max_members": 100_000,
+    "preferred_locale": "UTC",
+    "owner_id": 1,
+    "afk_channel_id": 464033278631084042,
+}
+guild_instance = discord.Guild(data=guild_data, state=unittest.mock.MagicMock())
+
+
+class MockGuild(CustomMockMixin, unittest.mock.Mock, HashableMixin):
+    """
+    A `Mock` subclass to mock `discord.Guild` objects.
+
+    A MockGuild instance will follow the specifications of a `discord.Guild` instance. This means
+    that if the code you're testing tries to access an attribute or method that normally does not
+    exist for a `discord.Guild` object this will raise an `AttributeError`. This is to make sure our
+    tests fail if the code we're testing uses a `discord.Guild` object in the wrong way.
+
+    One restriction of that is that if the code tries to access an attribute that normally does not
+    exist for `discord.Guild` instance but was added dynamically, this will raise an exception with
+    the mocked object. To get around that, you can set the non-standard attribute explicitly for the
+    instance of `MockGuild`:
+
+    >>> guild = MockGuild()
+    >>> guild.attribute_that_normally_does_not_exist = unittest.mock.MagicMock()
+
+    In addition to attribute simulation, mocked guild object will pass an `isinstance` check against
+    `discord.Guild`:
+
+    >>> guild = MockGuild()
+    >>> isinstance(guild, discord.Guild)
+    True
+
+    For more info, see the `Mocking` section in `tests/README.md`.
+    """
+    spec_set = guild_instance
+
+    def __init__(self, roles: Iterable[MockRole] | None = None, **kwargs) -> None:
+        default_kwargs = {"id": next(self.discord_id), "members": [], "chunked": True}
+        super().__init__(**collections.ChainMap(kwargs, default_kwargs))
+
+        if roles:
+            self.roles = [
+                MockRole(name="@everyone", position=1, id=0),
+                *roles
+            ]
+
+    @cached_property
+    def roles(self) -> list[MockRole]:
+        """Cached roles property."""
+        return [MockRole(name="@everyone", position=1, id=0)]
+
+
+# Create a Role instance to get a realistic Mock of `discord.Role`
+role_data = {"name": "role", "id": 1}
+role_instance = discord.Role(guild=guild_instance, state=unittest.mock.MagicMock(), data=role_data)
+
+
+class MockRole(CustomMockMixin, unittest.mock.Mock, ColourMixin, HashableMixin):
+    """
+    A Mock subclass to mock `discord.Role` objects.
+
+    Instances of this class will follow the specifications of `discord.Role` instances. For more
+    information, see the `MockGuild` docstring.
+    """
+    spec_set = role_instance
+
+    def __init__(self, **kwargs) -> None:
+        default_kwargs = {
+            "id": next(self.discord_id),
+            "name": "role",
+            "position": 1,
+            "colour": discord.Colour(0xdeadbf),
+            "permissions": discord.Permissions(),
+        }
+        super().__init__(**collections.ChainMap(kwargs, default_kwargs))
+
+        if isinstance(self.colour, int):
+            self.colour = discord.Colour(self.colour)
+
+        if isinstance(self.permissions, int):
+            self.permissions = discord.Permissions(self.permissions)
+
+        if "mention" not in kwargs:
+            self.mention = f"&{self.name}"
+
+    def __lt__(self, other):
+        """Simplified position-based comparisons similar to those of `discord.Role`."""
+        return self.position < other.position
+
+    def __ge__(self, other):
+        """Simplified position-based comparisons similar to those of `discord.Role`."""
+        return self.position >= other.position
+
+
+# Create a Member instance to get a realistic Mock of `discord.Member`
+member_data = {"user": "lemon", "roles": [1], "flags": 2}
+state_mock = unittest.mock.MagicMock()
+member_instance = discord.Member(data=member_data, guild=guild_instance, state=state_mock)
+
+
+class MockMember(CustomMockMixin, unittest.mock.Mock, ColourMixin, HashableMixin):
+    """
+    A Mock subclass to mock Member objects.
+
+    Instances of this class will follow the specifications of `discord.Member` instances. For more
+    information, see the `MockGuild` docstring.
+    """
+    spec_set = member_instance
+
+    def __init__(self, roles: Iterable[MockRole] | None = None, **kwargs) -> None:
+        default_kwargs = {"name": "member", "id": next(self.discord_id), "bot": False, "pending": False}
+        super().__init__(**collections.ChainMap(kwargs, default_kwargs))
+
+        self.roles = [MockRole(name="@everyone", position=1, id=0)]
+        if roles:
+            self.roles.extend(roles)
+        self.top_role = max(self.roles)
+
+        if "mention" not in kwargs:
+            self.mention = f"@{self.name}"
+
+    def get_role(self, role_id: int) -> MockRole | None:
+        return discord.utils.get(self.roles, id=role_id)
+
+
+# Create a User instance to get a realistic Mock of `discord.User`
+_user_data_mock = collections.defaultdict(unittest.mock.MagicMock, {
+    "accent_color": 0
+})
+user_instance = discord.User(
+    data=unittest.mock.MagicMock(get=unittest.mock.Mock(side_effect=_user_data_mock.get)),
+    state=unittest.mock.MagicMock()
+)
+
+
+class MockUser(CustomMockMixin, unittest.mock.Mock, ColourMixin, HashableMixin):
+    """
+    A Mock subclass to mock User objects.
+
+    Instances of this class will follow the specifications of `discord.User` instances. For more
+    information, see the `MockGuild` docstring.
+    """
+    spec_set = user_instance
+
+    def __init__(self, **kwargs) -> None:
+        default_kwargs = {"name": "user", "id": next(self.discord_id), "bot": False}
+        super().__init__(**collections.ChainMap(kwargs, default_kwargs))
+
+        if "mention" not in kwargs:
+            self.mention = f"@{self.name}"
+
+
+class MockAPIClient(CustomMockMixin, unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock APIClient objects.
+
+    Instances of this class will follow the specifications of `bot.api.APIClient` instances.
+    For more information, see the `MockGuild` docstring.
+    """
+    spec_set = APIClient
+
+
+def _get_mock_loop() -> unittest.mock.Mock:
+    """Return a mocked asyncio.AbstractEventLoop."""
+    loop = unittest.mock.create_autospec(spec=AbstractEventLoop, spec_set=True)
+
+    # Since calling `create_task` on our MockBot does not actually schedule the coroutine object
+    # as a task in the asyncio loop, this `side_effect` calls `close()` on the coroutine object
+    # to prevent "has not been awaited"-warnings.
+    def mock_create_task(coroutine, **kwargs):
+        coroutine.close()
+        return unittest.mock.Mock()
+    loop.create_task.side_effect = mock_create_task
+
+    return loop
+
+
+class MockBot(CustomMockMixin, unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock Bot objects.
+
+    Instances of this class will follow the specifications of `discord.ext.commands.Bot` instances.
+    For more information, see the `MockGuild` docstring.
+    """
+    spec_set = Bot(
+        command_prefix=unittest.mock.MagicMock(),
+        loop=_get_mock_loop(),
+        redis_session=unittest.mock.MagicMock(),
+        http_session=unittest.mock.MagicMock(),
+        allowed_roles=[1],
+        guild_id=1,
+        intents=discord.Intents.all(),
+    )
+    additional_spec_asyncs = ("wait_for",)
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        self.add_cog = unittest.mock.AsyncMock()
+
+    @cached_property
+    def loop(self) -> unittest.mock.Mock:
+        """Cached loop property."""
+        return _get_mock_loop()
+
+    @cached_property
+    def api_client(self) -> MockAPIClient:
+        """Cached api_client property."""
+        return MockAPIClient()
+
+    @cached_property
+    def http_session(self) -> unittest.mock.Mock:
+        """Cached http_session property."""
+        return unittest.mock.create_autospec(spec=ClientSession, spec_set=True)
+
+    @cached_property
+    def stats(self) -> unittest.mock.Mock:
+        """Cached stats property."""
+        return unittest.mock.create_autospec(spec=AsyncStatsClient, spec_set=True)
+
+
+# Create a TextChannel instance to get a realistic MagicMock of `discord.TextChannel`
+channel_data = {
+    "id": 1,
+    "type": "TextChannel",
+    "name": "channel",
+    "parent_id": 1234567890,
+    "topic": "topic",
+    "position": 1,
+    "nsfw": False,
+    "last_message_id": 1,
+    "bitrate": 1337,
+    "user_limit": 25,
+}
+state = unittest.mock.MagicMock()
+guild = unittest.mock.MagicMock()
+text_channel_instance = discord.TextChannel(state=state, guild=guild, data=channel_data)
+
+channel_data["type"] = "VoiceChannel"
+voice_channel_instance = discord.VoiceChannel(state=state, guild=guild, data=channel_data)
+
+
+class MockTextChannel(CustomMockMixin, unittest.mock.Mock, HashableMixin):
+    """
+    A MagicMock subclass to mock TextChannel objects.
+
+    Instances of this class will follow the specifications of `discord.TextChannel` instances. For
+    more information, see the `MockGuild` docstring.
+    """
+    spec_set = text_channel_instance
+
+    def __init__(self, **kwargs) -> None:
+        default_kwargs = {"id": next(self.discord_id), "name": "channel", "guild": MockGuild()}
+        super().__init__(**collections.ChainMap(kwargs, default_kwargs))
+
+        if "mention" not in kwargs:
+            self.mention = f"#{self.name}"
+
+
+class MockVoiceChannel(CustomMockMixin, unittest.mock.Mock, HashableMixin):
+    """
+    A MagicMock subclass to mock VoiceChannel objects.
+
+    Instances of this class will follow the specifications of `discord.VoiceChannel` instances. For
+    more information, see the `MockGuild` docstring.
+    """
+    spec_set = voice_channel_instance
+
+    def __init__(self, **kwargs) -> None:
+        default_kwargs = {"id": next(self.discord_id), "name": "channel", "guild": MockGuild()}
+        super().__init__(**collections.ChainMap(kwargs, default_kwargs))
+
+        if "mention" not in kwargs:
+            self.mention = f"#{self.name}"
+
+
+# Create data for the DMChannel instance
+state = unittest.mock.MagicMock()
+me = unittest.mock.MagicMock()
+dm_channel_data = {"id": 1, "recipients": [unittest.mock.MagicMock()]}
+dm_channel_instance = discord.DMChannel(me=me, state=state, data=dm_channel_data)
+
+
+class MockDMChannel(CustomMockMixin, unittest.mock.Mock, HashableMixin):
+    """
+    A MagicMock subclass to mock DMChannel objects.
+
+    Instances of this class will follow the specifications of `discord.DMChannel` instances. For
+    more information, see the `MockGuild` docstring.
+    """
+    spec_set = dm_channel_instance
+
+    def __init__(self, **kwargs) -> None:
+        default_kwargs = {"id": next(self.discord_id), "recipient": MockUser(), "me": MockUser(), "guild": None}
+        super().__init__(**collections.ChainMap(kwargs, default_kwargs))
+
+
+# Create CategoryChannel instance to get a realistic MagicMock of `discord.CategoryChannel`
+category_channel_data = {
+    "id": 1,
+    "type": discord.ChannelType.category,
+    "name": "category",
+    "position": 1,
+}
+
+state = unittest.mock.MagicMock()
+guild = unittest.mock.MagicMock()
+category_channel_instance = discord.CategoryChannel(
+    state=state, guild=guild, data=category_channel_data
+)
+
+
+class MockCategoryChannel(CustomMockMixin, unittest.mock.Mock, HashableMixin):
+    def __init__(self, **kwargs) -> None:
+        default_kwargs = {"id": next(self.discord_id)}
+        super().__init__(**collections.ChainMap(kwargs, default_kwargs))
+
+
+# Create a Message instance to get a realistic MagicMock of `discord.Message`
+message_data = {
+    "id": 1,
+    "webhook_id": 431341013479718912,
+    "attachments": [],
+    "embeds": [],
+    "application": {"id": 4, "description": "A Python Bot", "name": "Python Discord", "icon": None},
+    "activity": "mocking",
+    "channel": unittest.mock.MagicMock(),
+    "edited_timestamp": "2019-10-14T15:33:48+00:00",
+    "type": "message",
+    "pinned": False,
+    "mention_everyone": False,
+    "tts": None,
+    "content": "content",
+    "nonce": None,
+}
+state = unittest.mock.MagicMock()
+channel = unittest.mock.MagicMock()
+channel.type = discord.ChannelType.text
+message_instance = discord.Message(state=state, channel=channel, data=message_data)
+
+
+# Create a Context instance to get a realistic MagicMock of `discord.ext.commands.Context`
+context_instance = Context(
+    message=unittest.mock.MagicMock(),
+    prefix="$",
+    bot=MockBot(),
+    view=None
+)
+context_instance.invoked_from_error_handler = None
+
+
+class MockContext(CustomMockMixin, unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock Context objects.
+
+    Instances of this class will follow the specifications of `discord.ext.commands.Context`
+    instances. For more information, see the `MockGuild` docstring.
+    """
+    spec_set = context_instance
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.me = kwargs.get("me", MockMember())
+        self.bot = kwargs.get("bot", MockBot())
+        self.guild = kwargs.get("guild", MockGuild())
+        self.author = kwargs.get("author", MockMember())
+        self.channel = kwargs.get("channel", MockTextChannel())
+        self.message = kwargs.get("message", MockMessage())
+        self.invoked_from_error_handler = kwargs.get("invoked_from_error_handler", False)
+
+
+class MockInteraction(CustomMockMixin, unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock Interaction objects.
+
+    Instances of this class will follow the specifications of `discord.Interaction`
+    instances. For more information, see the `MockGuild` docstring.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.me = kwargs.get("me", MockMember())
+        self.client = kwargs.get("client", MockBot())
+        self.guild = kwargs.get("guild", MockGuild())
+        self.user = kwargs.get("user", MockMember())
+        self.channel = kwargs.get("channel", MockTextChannel())
+        self.message = kwargs.get("message", MockMessage())
+        self.invoked_from_error_handler = kwargs.get("invoked_from_error_handler", False)
+
+
+attachment_data = {
+    "id": 1,
+    "size": 14,
+    "filename": "jchrist.png",
+    "url": "https://google.com",
+    "proxy_url": "https://google.com",
+    "waveform": None,
+}
+attachment_instance = discord.Attachment(
+    data=attachment_data,
+    state=unittest.mock.MagicMock(),
+)
+
+
+class MockAttachment(CustomMockMixin, unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock Attachment objects.
+
+    Instances of this class will follow the specifications of `discord.Attachment` instances. For
+    more information, see the `MockGuild` docstring.
+    """
+    spec_set = attachment_instance
+
+
+message_reference_instance = discord.MessageReference(
+    message_id=unittest.mock.MagicMock(id=1),
+    channel_id=unittest.mock.MagicMock(id=2),
+    guild_id=unittest.mock.MagicMock(id=3)
+)
+
+
+class MockMessageReference(CustomMockMixin, unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock MessageReference objects.
+
+    Instances of this class will follow the specification of `discord.MessageReference` instances.
+    For more information, see the `MockGuild` docstring.
+    """
+    spec_set = message_reference_instance
+
+    def __init__(self, *, reference_author_is_bot: bool = False, **kwargs):
+        super().__init__(**kwargs)
+        referenced_msg_author = MockMember(name="bob", bot=reference_author_is_bot)
+        self.resolved = MockMessage(author=referenced_msg_author)
+
+
+class MockMessage(CustomMockMixin, unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock Message objects.
+
+    Instances of this class will follow the specifications of `discord.Message` instances. For more
+    information, see the `MockGuild` docstring.
+    """
+    spec_set = message_instance
+
+    def __init__(self, **kwargs) -> None:
+        default_kwargs = {"attachments": []}
+        super().__init__(**collections.ChainMap(kwargs, default_kwargs))
+        self.author = kwargs.get("author", MockMember())
+        self.channel = kwargs.get("channel", MockTextChannel())
+
+
+class MockInteractionMessage(MockMessage):
+    """
+    A MagicMock subclass to mock InteractionMessage objects.
+
+    Instances of this class will follow the specifications of `discord.InteractionMessage` instances. For more
+    information, see the `MockGuild` docstring.
+    """
+
+
+emoji_data = {"require_colons": True, "managed": True, "id": 1, "name": "hyperlemon"}
+emoji_instance = discord.Emoji(guild=MockGuild(), state=unittest.mock.MagicMock(), data=emoji_data)
+
+
+class MockEmoji(CustomMockMixin, unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock Emoji objects.
+
+    Instances of this class will follow the specifications of `discord.Emoji` instances. For more
+    information, see the `MockGuild` docstring.
+    """
+    spec_set = emoji_instance
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.guild = kwargs.get("guild", MockGuild())
+
+
+partial_emoji_instance = discord.PartialEmoji(animated=False, name="guido")
+
+
+class MockPartialEmoji(CustomMockMixin, unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock PartialEmoji objects.
+
+    Instances of this class will follow the specifications of `discord.PartialEmoji` instances. For
+    more information, see the `MockGuild` docstring.
+    """
+    spec_set = partial_emoji_instance
+
+
+reaction_instance = discord.Reaction(message=MockMessage(), data={"me": True}, emoji=MockEmoji())
+
+
+class MockReaction(CustomMockMixin, unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock Reaction objects.
+
+    Instances of this class will follow the specifications of `discord.Reaction` instances. For
+    more information, see the `MockGuild` docstring.
+    """
+    spec_set = reaction_instance
+
+    def __init__(self, **kwargs) -> None:
+        _users = kwargs.pop("users", [])
+        super().__init__(**kwargs)
+        self.emoji = kwargs.get("emoji", MockEmoji())
+        self.message = kwargs.get("message", MockMessage())
+
+        user_iterator = unittest.mock.AsyncMock()
+        user_iterator.__aiter__.return_value = _users
+        self.users.return_value = user_iterator
+
+        self.__str__.return_value = str(self.emoji)
+
+
+webhook_instance = discord.Webhook(data=unittest.mock.MagicMock(), session=unittest.mock.MagicMock())
+
+
+class MockAsyncWebhook(CustomMockMixin, unittest.mock.MagicMock):
+    """
+    A MagicMock subclass to mock Webhook objects using an AsyncWebhookAdapter.
+
+    Instances of this class will follow the specifications of `discord.Webhook` instances. For
+    more information, see the `MockGuild` docstring.
+    """
+    spec_set = webhook_instance
+    additional_spec_asyncs = ("send", "edit", "delete", "execute")
+
+@contextmanager
+def no_create_task():
+    def side_effect(coro, *_, **__):
+        coro.close()
+
+    with unittest.mock.patch("pydis_core.utils.scheduling.create_task") as create_task:
+        create_task.side_effect = side_effect
+        yield

--- a/pydis_core/utils/tests/helpers.py
+++ b/pydis_core/utils/tests/helpers.py
@@ -11,11 +11,11 @@ from functools import cached_property
 
 import discord
 from aiohttp import ClientSession
+from bot.bot import Bot
 from discord.ext.commands import Context
+
 from pydis_core.async_stats import AsyncStatsClient
 from pydis_core.site_api import APIClient
-
-from bot.bot import Bot
 from tests._autospec import autospec  # noqa: F401 other modules import it via this module
 
 for logger in logging.Logger.manager.loggerDict.values():

--- a/pydis_core/utils/tests/helpers.py
+++ b/pydis_core/utils/tests/helpers.py
@@ -11,12 +11,13 @@ from functools import cached_property
 
 import discord
 from aiohttp import ClientSession
-from bot.bot import Bot
 from discord.ext.commands import Context
 
+from pydis_core._bot import BotBase
 from pydis_core.async_stats import AsyncStatsClient
 from pydis_core.site_api import APIClient
-from tests._autospec import autospec  # noqa: F401 other modules import it via this module
+
+from ._autospec import autospec  # noqa: F401 other modules import it via this module
 
 for logger in logging.Logger.manager.loggerDict.values():
     # Set all loggers to CRITICAL by default to prevent screen clutter during testing
@@ -320,7 +321,7 @@ class MockBot(CustomMockMixin, unittest.mock.MagicMock):
     Instances of this class will follow the specifications of `discord.ext.commands.Bot` instances.
     For more information, see the `MockGuild` docstring.
     """
-    spec_set = Bot(
+    spec_set = BotBase(
         command_prefix=unittest.mock.MagicMock(),
         loop=_get_mock_loop(),
         redis_session=unittest.mock.MagicMock(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,3 +103,4 @@ known-first-party = ["dev", "pydis_core", "docs"]
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["ANN", "D"]
+"pydis_core/utils/tests/*" = ["ANN", "D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydis_core"
-version = "10.2.0"
+version = "10.3.0"
 description = "PyDis core provides core functionality and utility to the bots of the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"

--- a/tests/pydis_core/utils/tests/test_base.py
+++ b/tests/pydis_core/utils/tests/test_base.py
@@ -1,0 +1,87 @@
+import logging
+import unittest.mock
+
+from bot.log import get_logger
+from tests.base import LoggingTestsMixin, _CaptureLogHandler
+
+
+class LoggingTestCase(LoggingTestsMixin, unittest.TestCase):
+    pass
+
+
+class LoggingTestCaseTests(unittest.TestCase):
+    """Tests for the LoggingTestCase."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.log = get_logger(__name__)
+
+    def test_assert_not_logs_does_not_raise_with_no_logs(self):
+        """Test if LoggingTestCase.assertNotLogs does not raise when no logs were emitted."""
+        try:
+            with LoggingTestCase.assertNotLogs(self, level=logging.DEBUG):
+                pass
+        except AssertionError:  # pragma: no cover
+            self.fail("`self.assertNotLogs` raised an AssertionError when it should not!")
+
+    def test_assert_not_logs_raises_correct_assertion_error_when_logs_are_emitted(self):
+        """Test if LoggingTestCase.assertNotLogs raises AssertionError when logs were emitted."""
+        msg_regex = (
+            r"1 logs of DEBUG or higher were triggered on root:\n"
+            r'<LogRecord: tests\.test_base, [\d]+, .+[/\\]tests[/\\]test_base\.py, [\d]+, "Log!">'
+        )
+        with (
+            self.assertRaisesRegex(AssertionError, msg_regex),
+            LoggingTestCase.assertNotLogs(self, level=logging.DEBUG),
+        ):
+            self.log.debug("Log!")
+
+    def test_assert_not_logs_reraises_unexpected_exception_in_managed_context(self):
+        """Test if LoggingTestCase.assertNotLogs reraises an unexpected exception."""
+        with (
+            self.assertRaises(ValueError, msg="test exception"),
+            LoggingTestCase.assertNotLogs(self, level=logging.DEBUG),
+        ):
+            raise ValueError("test exception")
+
+    def test_assert_not_logs_restores_old_logging_settings(self):
+        """Test if LoggingTestCase.assertNotLogs reraises an unexpected exception."""
+        old_handlers = self.log.handlers[:]
+        old_level = self.log.level
+        old_propagate = self.log.propagate
+
+        with LoggingTestCase.assertNotLogs(self, level=logging.DEBUG):
+            pass
+
+        self.assertEqual(self.log.handlers, old_handlers)
+        self.assertEqual(self.log.level, old_level)
+        self.assertEqual(self.log.propagate, old_propagate)
+
+    def test_logging_test_case_works_with_logger_instance(self):
+        """Test if the LoggingTestCase captures logging for provided logger."""
+        log = get_logger("new_logger")
+        with self.assertRaises(AssertionError), LoggingTestCase.assertNotLogs(self, logger=log):
+            log.info("Hello, this should raise an AssertionError")
+
+    def test_logging_test_case_respects_alternative_logger(self):
+        """Test if LoggingTestCase only checks the provided logger."""
+        log_one = get_logger("log one")
+        log_two = get_logger("log two")
+        with LoggingTestCase.assertNotLogs(self, logger=log_one):
+            log_two.info("Hello, this should not raise an AssertionError")
+
+    def test_logging_test_case_respects_logging_level(self):
+        """Test if LoggingTestCase does not raise for a logging level lower than provided."""
+        with LoggingTestCase.assertNotLogs(self, level=logging.CRITICAL):
+            self.log.info("Hello, this should raise an AssertionError")
+
+    def test_capture_log_handler_default_initialization(self):
+        """Test if the _CaptureLogHandler is initialized properly."""
+        handler = _CaptureLogHandler()
+        self.assertFalse(handler.records)
+
+    def test_capture_log_handler_saves_record_on_emit(self):
+        """Test if the _CaptureLogHandler saves the log record when it's emitted."""
+        handler = _CaptureLogHandler()
+        handler.emit("Log message")
+        self.assertIn("Log message", handler.records)

--- a/tests/pydis_core/utils/tests/test_base.py
+++ b/tests/pydis_core/utils/tests/test_base.py
@@ -1,9 +1,8 @@
 import logging
 import unittest.mock
 
-from bot.log import get_logger
-
-from tests.base import LoggingTestsMixin, _CaptureLogHandler
+from pydis_core.utils.logging import get_logger
+from pydis_core.utils.tests.base import LoggingTestsMixin, _CaptureLogHandler
 
 
 class LoggingTestCase(LoggingTestsMixin, unittest.TestCase):
@@ -29,7 +28,7 @@ class LoggingTestCaseTests(unittest.TestCase):
         """Test if LoggingTestCase.assertNotLogs raises AssertionError when logs were emitted."""
         msg_regex = (
             r"1 logs of DEBUG or higher were triggered on root:\n"
-            r'<LogRecord: tests\.test_base, [\d]+, .+[/\\]tests[/\\]test_base\.py, [\d]+, "Log!">'
+            r'<LogRecord: test_base, [\d]+, .+[/\\]tests[/\\]test_base\.py, [\d]+, "Log!">'
         )
         with (
             self.assertRaisesRegex(AssertionError, msg_regex),

--- a/tests/pydis_core/utils/tests/test_base.py
+++ b/tests/pydis_core/utils/tests/test_base.py
@@ -2,6 +2,7 @@ import logging
 import unittest.mock
 
 from bot.log import get_logger
+
 from tests.base import LoggingTestsMixin, _CaptureLogHandler
 
 

--- a/tests/pydis_core/utils/tests/test_helpers.py
+++ b/tests/pydis_core/utils/tests/test_helpers.py
@@ -1,0 +1,353 @@
+import asyncio
+import unittest
+import unittest.mock
+
+import discord
+
+from tests import helpers
+
+
+class DiscordMocksTests(unittest.TestCase):
+    """Tests for our specialized discord.py mocks."""
+
+    def test_mock_role_default_initialization(self):
+        """Test if the default initialization of MockRole results in the correct object."""
+        role = helpers.MockRole()
+
+        # The `spec` argument makes sure `isinstance` checks with `discord.Role` pass
+        self.assertIsInstance(role, discord.Role)
+
+        self.assertEqual(role.name, "role")
+        self.assertEqual(role.position, 1)
+        self.assertEqual(role.mention, "&role")
+
+    def test_mock_role_alternative_arguments(self):
+        """Test if MockRole initializes with the arguments provided."""
+        role = helpers.MockRole(
+            name="Admins",
+            id=90210,
+            position=10,
+        )
+
+        self.assertEqual(role.name, "Admins")
+        self.assertEqual(role.id, 90210)
+        self.assertEqual(role.position, 10)
+        self.assertEqual(role.mention, "&Admins")
+
+    def test_mock_role_accepts_dynamic_arguments(self):
+        """Test if MockRole accepts and sets abitrary keyword arguments."""
+        role = helpers.MockRole(
+            guild="Dino Man",
+            hoist=True,
+        )
+
+        self.assertEqual(role.guild, "Dino Man")
+        self.assertTrue(role.hoist)
+
+    def test_mock_role_uses_position_for_less_than_greater_than(self):
+        """Test if `<` and `>` comparisons for MockRole are based on its position attribute."""
+        role_one = helpers.MockRole(position=1)
+        role_two = helpers.MockRole(position=2)
+        role_three = helpers.MockRole(position=3)
+
+        self.assertLess(role_one, role_two)
+        self.assertLess(role_one, role_three)
+        self.assertLess(role_two, role_three)
+        self.assertGreater(role_three, role_two)
+        self.assertGreater(role_three, role_one)
+        self.assertGreater(role_two, role_one)
+
+    def test_mock_member_default_initialization(self):
+        """Test if the default initialization of Mockmember results in the correct object."""
+        member = helpers.MockMember()
+
+        # The `spec` argument makes sure `isistance` checks with `discord.Member` pass
+        self.assertIsInstance(member, discord.Member)
+
+        self.assertEqual(member.name, "member")
+        self.assertListEqual(member.roles, [helpers.MockRole(name="@everyone", position=1, id=0)])
+        self.assertEqual(member.mention, "@member")
+
+    def test_mock_member_alternative_arguments(self):
+        """Test if MockMember initializes with the arguments provided."""
+        core_developer = helpers.MockRole(name="Core Developer", position=2)
+        member = helpers.MockMember(
+            name="Mark",
+            id=12345,
+            roles=[core_developer]
+        )
+
+        self.assertEqual(member.name, "Mark")
+        self.assertEqual(member.id, 12345)
+        self.assertListEqual(member.roles, [helpers.MockRole(name="@everyone", position=1, id=0), core_developer])
+        self.assertEqual(member.mention, "@Mark")
+
+    def test_mock_member_accepts_dynamic_arguments(self):
+        """Test if MockMember accepts and sets abitrary keyword arguments."""
+        member = helpers.MockMember(
+            nick="Dino Man",
+            colour=discord.Colour.default(),
+        )
+
+        self.assertEqual(member.nick, "Dino Man")
+        self.assertEqual(member.colour, discord.Colour.default())
+
+    def test_mock_guild_default_initialization(self):
+        """Test if the default initialization of Mockguild results in the correct object."""
+        guild = helpers.MockGuild()
+
+        # The `spec` argument makes sure `isistance` checks with `discord.Guild` pass
+        self.assertIsInstance(guild, discord.Guild)
+
+        self.assertListEqual(guild.roles, [helpers.MockRole(name="@everyone", position=1, id=0)])
+        self.assertListEqual(guild.members, [])
+
+    def test_mock_guild_alternative_arguments(self):
+        """Test if MockGuild initializes with the arguments provided."""
+        core_developer = helpers.MockRole(name="Core Developer", position=2)
+        guild = helpers.MockGuild(
+            roles=[core_developer],
+            members=[helpers.MockMember(id=54321)],
+        )
+
+        self.assertListEqual(guild.roles, [helpers.MockRole(name="@everyone", position=1, id=0), core_developer])
+        self.assertListEqual(guild.members, [helpers.MockMember(id=54321)])
+
+    def test_mock_guild_accepts_dynamic_arguments(self):
+        """Test if MockGuild accepts and sets abitrary keyword arguments."""
+        guild = helpers.MockGuild(
+            emojis=(":hyperjoseph:", ":pensive_ela:"),
+            premium_subscription_count=15,
+        )
+
+        self.assertTupleEqual(guild.emojis, (":hyperjoseph:", ":pensive_ela:"))
+        self.assertEqual(guild.premium_subscription_count, 15)
+
+    def test_mock_bot_default_initialization(self):
+        """Tests if MockBot initializes with the correct values."""
+        bot = helpers.MockBot()
+
+        # The `spec` argument makes sure `isistance` checks with `discord.ext.commands.Bot` pass
+        self.assertIsInstance(bot, discord.ext.commands.Bot)
+
+    def test_mock_context_default_initialization(self):
+        """Tests if MockContext initializes with the correct values."""
+        context = helpers.MockContext()
+
+        # The `spec` argument makes sure `isistance` checks with `discord.ext.commands.Context` pass
+        self.assertIsInstance(context, discord.ext.commands.Context)
+
+        self.assertIsInstance(context.bot, helpers.MockBot)
+        self.assertIsInstance(context.guild, helpers.MockGuild)
+        self.assertIsInstance(context.author, helpers.MockMember)
+
+    def test_mocks_allows_access_to_attributes_part_of_spec(self):
+        """Accessing attributes that are valid for the objects they mock should succeed."""
+        mocks = (
+            (helpers.MockGuild(), "name"),
+            (helpers.MockRole(), "hoist"),
+            (helpers.MockMember(), "display_name"),
+            (helpers.MockBot(), "user"),
+            (helpers.MockContext(), "invoked_with"),
+            (helpers.MockTextChannel(), "last_message"),
+            (helpers.MockMessage(), "mention_everyone"),
+        )
+
+        for mock, valid_attribute in mocks:
+            with self.subTest(mock=mock):
+                try:
+                    getattr(mock, valid_attribute)
+                except AttributeError:
+                    msg = f"accessing valid attribute `{valid_attribute}` raised an AttributeError"
+                    self.fail(msg)
+
+    @unittest.mock.patch(f"{__name__}.DiscordMocksTests.subTest")
+    @unittest.mock.patch(f"{__name__}.getattr")
+    def test_mock_allows_access_to_attributes_test(self, mock_getattr, mock_subtest):
+        """The valid attribute test should raise an AssertionError after an AttributeError."""
+        mock_getattr.side_effect = AttributeError
+
+        msg = "accessing valid attribute `name` raised an AttributeError"
+        with self.assertRaises(AssertionError, msg=msg):
+            self.test_mocks_allows_access_to_attributes_part_of_spec()
+
+    def test_mocks_rejects_access_to_attributes_not_part_of_spec(self):
+        """Accessing attributes that are invalid for the objects they mock should fail."""
+        mocks = (
+            helpers.MockGuild(),
+            helpers.MockRole(),
+            helpers.MockMember(),
+            helpers.MockBot(),
+            helpers.MockContext(),
+            helpers.MockTextChannel(),
+            helpers.MockMessage(),
+        )
+
+        for mock in mocks:
+            with self.subTest(mock=mock), self.assertRaises(AttributeError):
+                mock.the_cake_is_a_lie  # noqa: B018
+
+    def test_mocks_use_mention_when_provided_as_kwarg(self):
+        """The mock should use the passed `mention` instead of the default one if present."""
+        test_cases = (
+            (helpers.MockRole, "role mention"),
+            (helpers.MockMember, "member mention"),
+            (helpers.MockTextChannel, "channel mention"),
+        )
+
+        for mock_type, mention in test_cases:
+            with self.subTest(mock_type=mock_type, mention=mention):
+                mock = mock_type(mention=mention)
+                self.assertEqual(mock.mention, mention)
+
+    def test_create_test_on_mock_bot_closes_passed_coroutine(self):
+        """`bot.loop.create_task` should close the passed coroutine object to prevent warnings."""
+        async def dementati():
+            """Dummy coroutine for testing purposes."""
+
+        coroutine_object = dementati()
+
+        bot = helpers.MockBot()
+        bot.loop.create_task(coroutine_object)
+        with self.assertRaises(RuntimeError, msg="cannot reuse already awaited coroutine"):
+            asyncio.run(coroutine_object)
+
+    def test_user_mock_uses_explicitly_passed_mention_attribute(self):
+        """MockUser should use an explicitly passed value for user.mention."""
+        user = helpers.MockUser(mention="hello")
+        self.assertEqual(user.mention, "hello")
+
+
+class MockObjectTests(unittest.TestCase):
+    """Tests the mock objects and mixins we've defined."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.hashable_mocks = (helpers.MockRole, helpers.MockMember, helpers.MockGuild)
+
+    def test_colour_mixin(self):
+        """Test if the ColourMixin adds aliasing of color -> colour for child classes."""
+        class MockHemlock(unittest.mock.MagicMock, helpers.ColourMixin):
+            pass
+
+        hemlock = MockHemlock()
+        hemlock.color = 1
+        self.assertEqual(hemlock.colour, 1)
+        self.assertEqual(hemlock.colour, hemlock.color)
+
+    def test_hashable_mixin_hash_returns_id(self):
+        """Test if the HashableMixing uses the id attribute for hashing."""
+        class MockScragly(unittest.mock.Mock, helpers.HashableMixin):
+            pass
+
+        scragly = MockScragly()
+        scragly.id = 10
+        self.assertEqual(hash(scragly), scragly.id)
+
+    def test_hashable_mixin_uses_id_for_equality_comparison(self):
+        """Test if the HashableMixing uses the id attribute for hashing."""
+        class MockScragly(helpers.HashableMixin):
+            pass
+
+        scragly = MockScragly()
+        scragly.id = 10
+        eevee = MockScragly()
+        eevee.id = 10
+        python = MockScragly()
+        python.id = 20
+
+        self.assertTrue(scragly == eevee)
+        self.assertFalse(scragly == python)
+
+    def test_hashable_mixin_uses_id_for_nonequality_comparison(self):
+        """Test if the HashableMixing uses the id attribute for hashing."""
+        class MockScragly(helpers.HashableMixin):
+            pass
+
+        scragly = MockScragly()
+        scragly.id = 10
+        eevee = MockScragly()
+        eevee.id = 10
+        python = MockScragly()
+        python.id = 20
+
+        self.assertTrue(scragly != python)
+        self.assertFalse(scragly != eevee)
+
+    def test_mock_class_with_hashable_mixin_uses_id_for_hashing(self):
+        """Test if the MagicMock subclasses that implement the HashableMixin use id for hash."""
+        for mock in self.hashable_mocks:
+            with self.subTest(mock_class=mock):
+                instance = helpers.MockRole(id=100)
+                self.assertEqual(hash(instance), instance.id)
+
+    def test_mock_class_with_hashable_mixin_uses_id_for_equality(self):
+        """Test if MagicMocks that implement the HashableMixin use id for equality comparisons."""
+        for mock_class in self.hashable_mocks:
+            with self.subTest(mock_class=mock_class):
+                instance_one = mock_class()
+                instance_two = mock_class()
+                instance_three = mock_class()
+
+                instance_one.id = 10
+                instance_two.id = 10
+                instance_three.id = 20
+
+                self.assertTrue(instance_one == instance_two)
+                self.assertFalse(instance_one == instance_three)
+
+    def test_mock_class_with_hashable_mixin_uses_id_for_nonequality(self):
+        """Test if MagicMocks that implement HashableMixin use id for nonequality comparisons."""
+        for mock_class in self.hashable_mocks:
+            with self.subTest(mock_class=mock_class):
+                instance_one = mock_class()
+                instance_two = mock_class()
+                instance_three = mock_class()
+
+                instance_one.id = 10
+                instance_two.id = 10
+                instance_three.id = 20
+
+                self.assertFalse(instance_one != instance_two)
+                self.assertTrue(instance_one != instance_three)
+
+    def test_custom_mock_mixin_accepts_mock_seal(self):
+        """The `CustomMockMixin` should support `unittest.mock.seal`."""
+        class MyMock(helpers.CustomMockMixin, unittest.mock.MagicMock):
+
+            child_mock_type = unittest.mock.MagicMock
+            pass
+
+        mock = MyMock()
+        unittest.mock.seal(mock)
+        with self.assertRaises(AttributeError, msg="MyMock.shirayuki"):
+            mock.shirayuki = "hello!"
+
+    def test_spec_propagation_of_mock_subclasses(self):
+        """Test if the `spec` does not propagate to attributes of the mock object."""
+        test_values = (
+            (helpers.MockGuild, "features"),
+            (helpers.MockRole, "mentionable"),
+            (helpers.MockMember, "display_name"),
+            (helpers.MockBot, "owner_id"),
+            (helpers.MockContext, "command_failed"),
+            (helpers.MockMessage, "mention_everyone"),
+            (helpers.MockEmoji, "managed"),
+            (helpers.MockPartialEmoji, "url"),
+            (helpers.MockReaction, "me"),
+        )
+
+        for mock_type, valid_attribute in test_values:
+            with self.subTest(mock_type=mock_type, attribute=valid_attribute):
+                mock = mock_type()
+                self.assertTrue(isinstance(mock, mock_type))
+                attribute = getattr(mock, valid_attribute)
+                self.assertTrue(isinstance(attribute, mock_type.child_mock_type))
+
+    def test_custom_mock_mixin_mocks_async_magic_methods_with_async_mock(self):
+        """The CustomMockMixin should mock async magic methods with an AsyncMock."""
+        class MyMock(helpers.CustomMockMixin, unittest.mock.MagicMock):
+            pass
+
+        mock = MyMock()
+        self.assertIsInstance(mock.__aenter__, unittest.mock.AsyncMock)

--- a/tests/pydis_core/utils/tests/test_helpers.py
+++ b/tests/pydis_core/utils/tests/test_helpers.py
@@ -4,7 +4,7 @@ import unittest.mock
 
 import discord
 
-from tests import helpers
+from pydis_core.utils.tests import helpers
 
 
 class DiscordMocksTests(unittest.TestCase):


### PR DESCRIPTION
This PR migrates the test helpers from the bot repo into bot core, along with their tests.