### PR TITLE
Do not attempt to read response body if the HTTP response code is 204.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,9 @@
 Changelog
 =========
 
+- :release:`10.5.1 <14th December 2023>`
+- :bug:`198` Do not attempt to read response body if the HTTP response code is 204. Previously only :obj:`pydis_core.site_api.APIClient.delete` did this.
+
 - :release:`10.5.0 <10th December 2023>`
 - :support:`197` Mark dependencies using tilde version specifiers. This is to allow user of pydis core to use newer versions of these libraries without us having to cut a new release.
 

--- a/pydis_core/site_api.py
+++ b/pydis_core/site_api.py
@@ -96,7 +96,7 @@ class APIClient:
                 response_text = await response.text()
                 raise ResponseCodeError(response=response, response_text=response_text)
 
-    async def request(self, method: str, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict:
+    async def request(self, method: str, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict | None:
         """
         Send an HTTP request to the site API and return the JSON response.
 
@@ -107,50 +107,38 @@ class APIClient:
             **kwargs: Any extra keyword arguments to pass to :func:`aiohttp.request`.
 
         Returns:
-            The JSON response the API returns.
+            The JSON response the API returns, or :obj:`None` if the response code is 204.
 
         Raises:
             :exc:`ResponseCodeError`:
                 If the response is not OK and ``raise_for_status`` is True.
         """
         async with self.session.request(method.upper(), self._url_for(endpoint), **kwargs) as resp:
-            await self.maybe_raise_for_status(resp, raise_for_status)
-            return await resp.json()
-
-    async def get(self, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict:
-        """Equivalent to :meth:`APIClient.request` with GET passed as the method."""
-        return await self.request("GET", endpoint, raise_for_status=raise_for_status, **kwargs)
-
-    async def patch(self, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict:
-        """Equivalent to :meth:`APIClient.request` with PATCH passed as the method."""
-        return await self.request("PATCH", endpoint, raise_for_status=raise_for_status, **kwargs)
-
-    async def post(self, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict:
-        """Equivalent to :meth:`APIClient.request` with POST passed as the method."""
-        return await self.request("POST", endpoint, raise_for_status=raise_for_status, **kwargs)
-
-    async def put(self, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict:
-        """Equivalent to :meth:`APIClient.request` with PUT passed as the method."""
-        return await self.request("PUT", endpoint, raise_for_status=raise_for_status, **kwargs)
-
-    async def delete(self, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict | None:
-        """
-        Send a DELETE request to the site API and return the JSON response.
-
-        Args:
-            endpoint: The endpoint to send the request to.
-            raise_for_status: Whether or not to raise an exception if the response is not OK.
-            **kwargs: Any extra keyword arguments to pass to :func:`aiohttp.request`.
-
-        Returns:
-            The JSON response the API returns, or None if the response is 204 No Content.
-        """
-        async with self.session.delete(self._url_for(endpoint), **kwargs) as resp:
             if resp.status == 204:
                 return None
 
             await self.maybe_raise_for_status(resp, raise_for_status)
             return await resp.json()
+
+    async def get(self, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict | None:
+        """Equivalent to :meth:`APIClient.request` with GET passed as the method."""
+        return await self.request("GET", endpoint, raise_for_status=raise_for_status, **kwargs)
+
+    async def patch(self, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict | None:
+        """Equivalent to :meth:`APIClient.request` with PATCH passed as the method."""
+        return await self.request("PATCH", endpoint, raise_for_status=raise_for_status, **kwargs)
+
+    async def post(self, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict | None:
+        """Equivalent to :meth:`APIClient.request` with POST passed as the method."""
+        return await self.request("POST", endpoint, raise_for_status=raise_for_status, **kwargs)
+
+    async def put(self, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict | None:
+        """Equivalent to :meth:`APIClient.request` with PUT passed as the method."""
+        return await self.request("PUT", endpoint, raise_for_status=raise_for_status, **kwargs)
+
+    async def delete(self, endpoint: str, *, raise_for_status: bool = True, **kwargs) -> dict | None:
+        """Equivalent to :meth:`APIClient.request` with DELETE passed as the method."""
+        return await self.request("DELETE", endpoint, raise_for_status=raise_for_status, **kwargs)
 
 
 __all__ = ["APIClient", "ResponseCodeError"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydis_core"
-version = "10.5.0"
+version = "10.5.1"
 description = "PyDis core provides core functionality and utility to the bots of the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"


### PR DESCRIPTION
Previously only `pydis_core.site_api.APIClient.delete` did this.

Changelog:
![image](https://github.com/python-discord/bot-core/assets/9753350/6d9c66bc-82c2-4264-b976-80a710fa3d10)

Changed docs:
![image](https://github.com/python-discord/bot-core/assets/9753350/2a2de605-849a-4b94-afc1-9421b8567b31)
![image](https://github.com/python-discord/bot-core/assets/9753350/ab953e2f-6d28-43c5-9b1e-74f3196f9a50)
