### PR TITLE
More breaking changes for 11.0

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.10", "3.11"]
+        python_version: ["3.10", "3.11", "3.12"]
 
     name: Run Linting & Test Suites
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: ["3.10", "3.11", "3.12"]
+        python_version: ["3.11", "3.12"]
 
     name: Run Linting & Test Suites
     runs-on: ubuntu-latest

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@
 Changelog
 =========
 
+- :breaking:`208` Drop support for Pydantic 1.X
 - :breaking:`207` Enable more ruff linting rules. See :literal-url:`GitHub release notes <https://github.com/python-discord/bot-core/releases/tag/v11.0.0>` for breaking changes.
 - :support:`206` Bump ruff from 0.1.15 to 0.2.2, using the new lint config namespace, and linting with the new rules.
 - :support:`204` Document the instance attributes of :obj:`pydis_core.BotBase`.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,7 @@ Changelog
 
 - :breaking:`208` Split ``fakeredis`` optional dependency from the ``async-rediscache`` extra. You can now install with ``[fakeredis]`` to just install fakeredis (with lua support), ``[async-rediscache]`` to install just ``async-rediscache``, or use either ``[all]`` or ``[async-rediscache,fakeredis]`` to install both. This allows users who do no rely on fakeredis to install in 3.12 environments.
 - :support:`208` Add support for Python 3.12. Be aware, at time of writing, our usage of fakeredis does not currently support 3.12. This is due to :literal-url:`this lupa issue<https://github.com/scoder/lupa/issues/245>`. Lupa is required by async-rediscache for lua script support within fakeredis. As such, fakeredis can not be installed in a Python 3.12 environment.
+- :breaking:`208` Drop support for Python 3.10
 - :breaking:`208` Drop support for Pydantic 1.X
 - :breaking:`207` Enable more ruff linting rules. See :literal-url:`GitHub release notes <https://github.com/python-discord/bot-core/releases/tag/v11.0.0>` for breaking changes.
 - :support:`206` Bump ruff from 0.1.15 to 0.2.2, using the new lint config namespace, and linting with the new rules.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@
 Changelog
 =========
 
+- :breaking:`208` Split ``fakeredis`` optional dependency from the ``async-rediscache`` extra. You can now install with ``[fakeredis]`` to just install fakeredis (with lua support), ``[async-rediscache]`` to install just ``async-rediscache``, or use either ``[all]`` or ``[async-rediscache,fakeredis]`` to install both. This allows users who do no rely on fakeredis to install in 3.12 environments.
+- :breaking:`208` Drop support for Python 3.10
 - :breaking:`208` Drop support for Pydantic 1.X
 - :breaking:`207` Enable more ruff linting rules. See :literal-url:`GitHub release notes <https://github.com/python-discord/bot-core/releases/tag/v11.0.0>` for breaking changes.
 - :support:`206` Bump ruff from 0.1.15 to 0.2.2, using the new lint config namespace, and linting with the new rules.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 =========
 
 - :breaking:`208` Split ``fakeredis`` optional dependency from the ``async-rediscache`` extra. You can now install with ``[fakeredis]`` to just install fakeredis (with lua support), ``[async-rediscache]`` to install just ``async-rediscache``, or use either ``[all]`` or ``[async-rediscache,fakeredis]`` to install both. This allows users who do no rely on fakeredis to install in 3.12 environments.
-- :breaking:`208` Drop support for Python 3.10
+- :support:`208` Add support for Python 3.12. Be aware, at time of writing, our usage of fakeredis does not currently support 3.12. This is due to :literal-url:`this lupa issue<https://github.com/scoder/lupa/issues/245>`. Lupa is required by async-rediscache for lua script support within fakeredis. As such, fakeredis can not be installed in a Python 3.12 environment.
 - :breaking:`208` Drop support for Pydantic 1.X
 - :breaking:`207` Enable more ruff linting rules. See :literal-url:`GitHub release notes <https://github.com/python-discord/bot-core/releases/tag/v11.0.0>` for breaking changes.
 - :support:`206` Bump ruff from 0.1.15 to 0.2.2, using the new lint config namespace, and linting with the new rules.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Changelog
 - :breaking:`208` Drop support for Python 3.10
 - :breaking:`208` Drop support for Pydantic 1.X
 - :breaking:`207` Enable more ruff linting rules. See :literal-url:`GitHub release notes <https://github.com/python-discord/bot-core/releases/tag/v11.0.0>` for breaking changes.
+- :support:`208` Bump ruff to 0.3.0 and target Python 3.11 now that 3.10 isn't supported.
 - :support:`206` Bump ruff from 0.1.15 to 0.2.2, using the new lint config namespace, and linting with the new rules.
 - :support:`204` Document the instance attributes of :obj:`pydis_core.BotBase`.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -101,7 +101,6 @@ files = [
 
 [package.dependencies]
 aiosignal = ">=1.1.2"
-async-timeout = {version = ">=4.0,<5.0", markers = "python_version < \"3.11\""}
 attrs = ">=17.3.0"
 frozenlist = ">=1.1.1"
 multidict = ">=4.5,<7.0"
@@ -167,7 +166,7 @@ fakeredis = ["fakeredis[lua] (>=1.7.1)"]
 name = "async-timeout"
 version = "4.0.3"
 description = "Timeout context manager for asyncio programs"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
@@ -543,20 +542,6 @@ files = [
     {file = "docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"},
     {file = "docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"},
 ]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.2.0"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"},
-    {file = "exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"},
-]
-
-[package.extras]
-test = ["pytest (>=6)"]
 
 [[package]]
 name = "execnet"
@@ -1394,11 +1379,9 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=1.4,<2.0"
-tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -2051,5 +2034,5 @@ fakeredis = ["fakeredis"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "3.10.* || 3.11.*"
-content-hash = "088f8fb148adf7b38413f7888329059ad8f8f6a99d973d22506b86328678c54d"
+python-versions = "3.11.* || 3.12.*"
+content-hash = "928dd7398412401c9cda11bd485ed0e54583e2c021b5a69895aa5a15be334b41"

--- a/poetry.lock
+++ b/poetry.lock
@@ -158,7 +158,6 @@ files = [
 ]
 
 [package.dependencies]
-fakeredis = {version = ">=1.7.1", extras = ["lua"], optional = true, markers = "extra == \"fakeredis\""}
 redis = ">=4.2,<5.0"
 
 [package.extras]
@@ -2046,9 +2045,11 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [extras]
+all = ["async-rediscache", "fakeredis"]
 async-rediscache = ["async-rediscache"]
+fakeredis = ["fakeredis"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "3.10.* || 3.11.*"
-content-hash = "10074d9691a66b5086362d12ff78bc54028382f17b3b512d942e7d47c6b7d86d"
+content-hash = "088f8fb148adf7b38413f7888329059ad8f8f6a99d973d22506b86328678c54d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2051,4 +2051,4 @@ async-rediscache = ["async-rediscache"]
 [metadata]
 lock-version = "2.0"
 python-versions = "3.10.* || 3.11.*"
-content-hash = "012783d11abde1a1db5165482a61de9a342e6dd3f2a0ecba5f56777486af4e7f"
+content-hash = "10074d9691a66b5086362d12ff78bc54028382f17b3b512d942e7d47c6b7d86d"

--- a/pydis_core/utils/_monkey_patches.py
+++ b/pydis_core/utils/_monkey_patches.py
@@ -1,7 +1,7 @@
 """Contains all common monkey patches, used to alter discord to fit our needs."""
 
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from functools import partial, partialmethod
 
 from discord import Forbidden, http
@@ -50,13 +50,13 @@ def _patch_typing() -> None:
 
     async def honeybadger_type(self: http.HTTPClient, channel_id: int) -> None:
         nonlocal last_403
-        if last_403 and (datetime.now(tz=timezone.utc) - last_403) < timedelta(minutes=5):
+        if last_403 and (datetime.now(tz=UTC) - last_403) < timedelta(minutes=5):
             log.warning("Not sending typing event, we got a 403 less than 5 minutes ago.")
             return
         try:
             await original(self, channel_id)
         except Forbidden:
-            last_403 = datetime.now(tz=timezone.utc)
+            last_403 = datetime.now(tz=UTC)
             log.warning("Got a 403 from typing event!")
 
     http.HTTPClient.send_typing = honeybadger_type

--- a/pydis_core/utils/cooldown.py
+++ b/pydis_core/utils/cooldown.py
@@ -81,7 +81,7 @@ class _SeparatedArguments:
         for item in call_arguments:
             try:
                 hash(item)
-            except TypeError:  # noqa: PERF203
+            except TypeError:
                 non_hashable.append(item)
             else:
                 hashable.append(item)

--- a/pydis_core/utils/cooldown.py
+++ b/pydis_core/utils/cooldown.py
@@ -25,8 +25,6 @@ _ArgsList = list[object]
 _HashableArgsTuple = tuple[Hashable, ...]
 
 if typing.TYPE_CHECKING:
-    import typing_extensions
-
     from pydis_core import BotBase
 
 P = typing.ParamSpec("P")
@@ -75,7 +73,7 @@ class _SeparatedArguments:
     non_hashable: _ArgsList
 
     @classmethod
-    def from_full_arguments(cls, call_arguments: Iterable[object]) -> typing_extensions.Self:
+    def from_full_arguments(cls, call_arguments: Iterable[object]) -> typing.Self:
         """Create a new instance from full call arguments."""
         hashable = list[Hashable]()
         non_hashable = list[object]()

--- a/pydis_core/utils/pagination.py
+++ b/pydis_core/utils/pagination.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Sequence
 from contextlib import suppress
 from functools import partial
@@ -267,7 +266,7 @@ class LinePaginator(Paginator):
         for line in lines:
             try:
                 paginator.add_line(line, empty=empty)
-            except Exception:  # noqa: PERF203
+            except Exception:
                 log.exception(f"Failed to add line to paginator: '{line}'")
                 raise  # Should propagate
             else:
@@ -336,7 +335,7 @@ class LinePaginator(Paginator):
                 else:
                     reaction, user = await ctx.bot.wait_for("reaction_add", timeout=timeout, check=check)
                 log.trace(f"Got reaction: {reaction}")
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 log.debug("Timed out waiting for a reaction")
                 break  # We're done, no reactions for the last 5 minutes
 

--- a/pydis_core/utils/paste_service.py
+++ b/pydis_core/utils/paste_service.py
@@ -109,7 +109,7 @@ async def send_to_paste_service(
     payload = {
         "expiry": "30days",
         "long": "on",  # Use a longer URI for the paste.
-        "files": [file.dict() for file in files]  # Use file.model_dump() when we drop support for pydantic 1.X
+        "files": [file.model_dump() for file in files]
     }
     for attempt in range(1, FAILED_REQUEST_ATTEMPTS + 1):
         try:

--- a/pydis_core/utils/scheduling.py
+++ b/pydis_core/utils/scheduling.py
@@ -5,7 +5,7 @@ import contextlib
 import inspect
 import typing
 from collections import abc
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from functools import partial
 
 from discord.errors import Forbidden
@@ -103,7 +103,7 @@ class Scheduler:
             task_id: A unique ID to create the task with.
             coroutine: The function to be called.
         """
-        now_datetime = datetime.now(time.tzinfo) if time.tzinfo else datetime.now(tz=timezone.utc)
+        now_datetime = datetime.now(time.tzinfo) if time.tzinfo else datetime.now(tz=UTC)
         delay = (time - now_datetime).total_seconds()
         if delay > 0:
             coroutine = self._await_later(delay, task_id, coroutine)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ python = "3.10.* || 3.11.*"
 
 "discord.py" = "~=2.3.2"
 async-rediscache = { version = "1.0.0rc2", extras = ["fakeredis"], optional = true }
-pydantic = ">=1.7.4,<3.0.0"
+pydantic = "~=2.6"
 statsd  = "~=4.0"
 aiodns = "~=3.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ source_pkgs = ["pydis_core"]
 source = ["tests"]
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 extend-exclude = [".cache"]
 output-format = "concise"
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ repository = "https://github.com/python-discord/bot-core"
 keywords = ["bot", "discord", "discord.py"]
 
 [tool.poetry.dependencies]
-python = "3.10.* || 3.11.*"
+python = "3.10.* || 3.11.* || 3.12.*"
 
 "discord.py" = "~=2.3.2"
 async-rediscache = { version = "1.0.0rc2", optional = true }
-fakeredis = { version = "~=2.0", extras = ["lua"], optional = true }
+fakeredis = { version = "~=2.0", extras = ["lua"], optional = true, python = "<3.12" }
 pydantic = "~=2.6"
 statsd  = "~=4.0"
 aiodns = "~=3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,16 @@ keywords = ["bot", "discord", "discord.py"]
 python = "3.10.* || 3.11.*"
 
 "discord.py" = "~=2.3.2"
-async-rediscache = { version = "1.0.0rc2", extras = ["fakeredis"], optional = true }
+async-rediscache = { version = "1.0.0rc2", optional = true }
+fakeredis = { version = "~=2.0", extras = ["lua"], optional = true }
 pydantic = "~=2.6"
 statsd  = "~=4.0"
 aiodns = "~=3.1"
 
 [tool.poetry.extras]
 async-rediscache = ["async-rediscache"]
+fakeredis = ["fakeredis"]
+all = ["async-rediscache", "fakeredis"]
 
 [tool.poetry.group.dev.dependencies]
 taskipy = "1.12.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/python-discord/bot-core"
 keywords = ["bot", "discord", "discord.py"]
 
 [tool.poetry.dependencies]
-python = "3.10.* || 3.11.* || 3.12.*"
+python = "3.11.* || 3.12.*"
 
 "discord.py" = "~=2.3.2"
 async-rediscache = { version = "1.0.0rc2", optional = true }
@@ -49,7 +49,6 @@ pytest-xdist = "3.5.0"
 [tool.poetry.group.lint.dependencies]
 ruff = "0.3.0"
 pre-commit = "3.6.2"
-typing-extensions = "4.10.0"
 
 [tool.poetry.group.doc.dependencies]
 Sphinx = "7.2.6"
@@ -60,7 +59,6 @@ six = "1.16.0"
 releases = "2.1.1"
 sphinx-multiversion = "0.2.4"
 docstring-parser = "0.15"
-typing-extensions = "4.10.0"
 tomli = "2.0.1"
 
 [tool.taskipy.tasks]


### PR DESCRIPTION
This adds a few more breaking changes that I've wanted to do for a while since we're making a new major version.

1. Drop Pydantic 1.X support. We had to use a deprecated function for backwards compat. It's been out long enough that I feel comfortable dropping support for it.
2. Spliting fakeredis from the async-rediscache extra. This means that uses of this lib can install async-redis cache without having to install fakeredis, this allows for 3.12 support
3. Drop support for 3.10. Supporting the last 2 minor versions seems reaosnable. Dropping 3.10 means we can drop a few imports that were annoying to keep up to date.

# Changelog preview
![image](https://github.com/python-discord/bot-core/assets/9753350/7a037b96-6cfd-4835-afa4-a8a7473548a4)

# v11 Github release notes draft

## Breaking Changes
This release has a number of breaking changes.
1. Pydantic 1.x is no longer supported. You can follow the Pydantic [migration guide](https://docs.pydantic.dev/2.0/migration/) if you havne't updated yet.
2. `fakeredis` is no longer installed along side the `async-rediscache` extra. If you need `fakeredis` you can use the `[fakeredis]` extra. You can also use either `[all]` or `[async-rediscache,fakeredis]` to install both.
3. Python 3.10 is no longer supported.
4. Boolean default and boolean-typed positional arguments in function definition are now keyword args only. The arg names and functions are listed below.
   * `sync_app_commands` in `pydis_core.BotBase.load_extensions()`
   * `should_raise` in `pydis_core.site_api.APIClient.maybe_raise_for_status()`
   * `fail_silently` in `pydis_core.utils.checks.in_whitelist_check()`
   * All args other than `pagination_emojis, lines, ctx, embed` in `pydis_core.utils.pagination.LinePaginator.paginate()`

## What's Changed
* Split ``fakeredis`` optional dependency from the ``async-rediscache`` extra, by @ChrisLovering in https://github.com/python-discord/bot-core/pull/208
* Add support for Python 3.12, by @ChrisLovering in https://github.com/python-discord/bot-core/pull/208
   * Be aware, at time of writing, our usage of fakeredis does not currently support 3.12. This is due to [this lupa issue](https://github.com/scoder/lupa/issues/245). Lupa is required by async-rediscache for lua script support within fakeredis. As such, fakeredis can not be installed in a Python 3.12 environment
* Drop support for Python 3.10, by @ChrisLovering in https://github.com/python-discord/bot-core/pull/208
* Drop support for Pydantic 1.X, by @ChrisLovering in https://github.com/python-discord/bot-core/pull/208
* Enable more ruff linting rules, by @ChrisLovering in https://github.com/python-discord/bot-core/pull/206
* Bump ruff to 0.3.0 and target Python 3.11 now that 3.10 isn't supported, by @ChrisLovering in https://github.com/python-discord/bot-core/pull/208
* Document the instance attributes of `pydis_core.BotBase`, by @shtlrs in https://github.com/python-discord/bot-core/pull/204
* Bump ruff from 0.1.15 to 0.2.2, using the new lint config namespace, and linting with the new rules, by @ChrisLovering in https://github.com/python-discord/bot-core/pull/206

**Full Changelog**: https://github.com/python-discord/bot-core/compare/v10.7.0...v11.0.0