### PR TITLE
Extract original error upon exceptions, if any

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@
 Changelog
 =========
 
+- :bug:`209` Extract original error from :obj:`discord.ext.commands.errors.CommandInvokeError` before handling it.
 - :release:`11.0.0 <18th March 2024>`
 - :breaking:`208` Split ``fakeredis`` optional dependency from the ``async-rediscache`` extra. You can now install with ``[fakeredis]`` to just install fakeredis (with lua support), ``[async-rediscache]`` to install just ``async-rediscache``, or use either ``[all]`` or ``[async-rediscache,fakeredis]`` to install both. This allows users who do no rely on fakeredis to install in 3.12 environments.
 - :support:`208` Add support for Python 3.12. Be aware, at time of writing, our usage of fakeredis does not currently support 3.12. This is due to :literal-url:`this lupa issue<https://github.com/scoder/lupa/issues/245>`. Lupa is required by async-rediscache for lua script support within fakeredis. As such, fakeredis can not be installed in a Python 3.12 environment.

--- a/pydis_core/utils/error_handling/commands/manager.py
+++ b/pydis_core/utils/error_handling/commands/manager.py
@@ -29,6 +29,7 @@ class CommandErrorManager:
         Iterate through available handlers by registration order, and choose the first one capable of handling
         the error as determined by `should_handle_error`; there is no priority system.
         """
+        error = getattr(error, "original", error)
         for handler in self._handlers + [self._default]:
             if await handler.should_handle_error(error):
                 callback = self._get_callback(handler, context_or_interaction)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydis_core"
-version = "11.0.0"
+version = "11.0.1"
 description = "PyDis core provides core functionality and utility to the bots of the Python Discord community."
 authors = ["Python Discord <info@pythondiscord.com>"]
 license = "MIT"


### PR DESCRIPTION
Discord py wraps errors in a `CommandInvokeError` instance, which hides the original error and results in only having the default error handler being invoked.