### PR TITLE
Update discord invite regex

### DIFF
--- a/pydis_core/utils/regex.py
+++ b/pydis_core/utils/regex.py
@@ -10,7 +10,7 @@ DISCORD_INVITE = re.compile(
         r"(gg|me)"                               # TLDs that embed within discord
         r"|com(\/|slash|\\)invite"               # Only match com/invite
     r")"
-    r"(/|slash|\\)"                              # / or \ or 'slash'
+    r"(/|slash|\\+)"                              # / or 'slash' or 1+ of \
     r"(?P<invite>\S+)",                          # the invite code itself
     flags=re.IGNORECASE
 )


### PR DESCRIPTION
Allows for more than one `\` that occurs before the invite code, which is apparently valid.
Tested against a few known discord invites we see in regex101. Can provide the link to the regex101 testing if needed.